### PR TITLE
fix(links): left-align labels next to icons

### DIFF
--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -1790,6 +1790,7 @@ body.ws-crt::after {
 .ws-links-list {
   width: 100%;
 }
+.ws-links-list .ws-channel-label { justify-self: start; }
 @media (max-width: 640px) {
   .ws-links { padding: 56px 18px; }
   .ws-links-list .ws-channel { grid-template-columns: auto 1fr auto !important; }

--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -1795,6 +1795,7 @@ body.ws-crt::after {
   .ws-links { padding: 56px 18px; }
   .ws-links-list .ws-channel { grid-template-columns: auto 1fr auto !important; }
   .ws-links-list .ws-channel-handle { display: none; }
+  .ws-links-list .ws-channel-label { justify-self: center; }
 }
 
 /* === Marginalia ===


### PR DESCRIPTION
## Summary

Labels on the `/links` page (LINKEDIN, GITHUB, EMAIL, MEDIUM, SPACE CAST) were centered in the `1fr` grid cell between the icon and handle, because `.ws-channel-label` had no explicit `justify-self`. This adds a single scoped rule `.ws-links-list .ws-channel-label { justify-self: start; }` so each label sits immediately after its icon on the left — matching the intent `[icon] LABEL .................... [handle →]` — without touching the Contact component that shares `.ws-channel` styles.

**Before:** `[icon] ............. CENTERED LABEL ............. [handle →]`
**After:** `[icon] LABEL .................... [handle →]`

## Viewports tested

- 375×667 (iPhone SE) — labels left-aligned, handle hidden per existing mobile rule
- 1440×900 (notebook) — labels left-aligned, handle visible on right