### PR TITLE
fix: mobile overflow, footer rebalance, podcast bars, PDF crop

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "8.5.14",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "react-wrap-balancer": "^1.1.1",
     "tailwindcss": "4.3.0",
     "typescript": "6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   react-dom:
     specifier: 19.2.6
     version: 19.2.6(react@19.2.6)
+  react-wrap-balancer:
+    specifier: ^1.1.1
+    version: 1.1.1(react@19.2.6)
   tailwindcss:
     specifier: 4.3.0
     version: 4.3.0
@@ -6404,6 +6407,14 @@ packages:
   /react-is@19.2.6:
     resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
     dev: true
+
+  /react-wrap-balancer@1.1.1(react@19.2.6):
+    resolution: {integrity: sha512-AB+l7FPRWl6uZ28VcJ8skkwLn2+UC62bjiw8tQUrZPlEWDVnR9MG0lghyn7EyxuJSsFEpht4G+yh2WikEqQ/5Q==}
+    peerDependencies:
+      react: '>=16.8.0 || ^17.0.0 || ^18'
+    dependencies:
+      react: 19.2.6
+    dev: false
 
   /react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}

--- a/scripts/get-pdf.js
+++ b/scripts/get-pdf.js
@@ -47,21 +47,37 @@ const getPdf = async () => {
     );
   }
 
-  // Evaluate the actual height of the page body
-  const bodyHandle = await page.$("body");
-  const { height } = await bodyHandle.boundingBox();
-  await bodyHandle.dispose();
-
-  // For some reason, the pdf has extra padding at the bottom.
-  // This is a hacky way to remove it.
-  const EXTRA_BOTTOM_PADDING = 500;
+  // Measure the bottom of the last meaningful element on the page. Using
+  // body.scrollHeight pulls in trailing margin/padding plus any decorative
+  // overflow, which is what produces the long blank page at the end of the
+  // PDF. The footer is the last semantic block, so we cap the export to its
+  // bottom edge plus a small breathing margin.
   const WEB_WIDTH = 1200;
+  const BOTTOM_MARGIN = 32;
+  const height = await page.evaluate((margin) => {
+    const candidates = [
+      ".ws-footer",
+      "#contact",
+      "footer",
+      "main",
+    ];
+    let bottom = 0;
+    for (const sel of candidates) {
+      const el = document.querySelector(sel);
+      if (!el) continue;
+      const rect = el.getBoundingClientRect();
+      const elBottom = rect.bottom + window.scrollY;
+      if (elBottom > bottom) bottom = elBottom;
+    }
+    if (!bottom) bottom = document.body.scrollHeight;
+    return Math.ceil(bottom + margin);
+  }, BOTTOM_MARGIN);
 
   const pdf = await page.pdf({
     printBackground: true,
     waitForFonts: true,
     width: WEB_WIDTH,
-    height: Math.ceil(height - EXTRA_BOTTOM_PADDING),
+    height,
     pageRanges: "1", // Ensures that only the first page is printed.
   });
 
@@ -75,8 +91,19 @@ const getPdf = async () => {
   fs.writeFileSync(tmpOut, pdf);
 
   try {
+    // /ebook keeps the warm gradients legible while halving the raster cost.
+    // We override the image resolutions explicitly (~150dpi color) so the
+    // hero glow doesn't band, plus turn on duplicate-image detection and
+    // font subsetting for additional savings.
     execSync(
-      `gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.5 -dPDFSETTINGS=/ebook -dNOPAUSE -dQUIET -dBATCH -sOutputFile=${finalOut} ${tmpOut}`,
+      `gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.5 -dPDFSETTINGS=/ebook \
+        -dDetectDuplicateImages=true -dCompressFonts=true -dSubsetFonts=true \
+        -dColorImageDownsampleType=/Bicubic -dColorImageResolution=150 \
+        -dGrayImageDownsampleType=/Bicubic -dGrayImageResolution=150 \
+        -dMonoImageDownsampleType=/Bicubic -dMonoImageResolution=300 \
+        -dAutoFilterColorImages=false -dColorImageFilter=/DCTEncode \
+        -dAutoFilterGrayImages=false -dGrayImageFilter=/DCTEncode \
+        -dNOPAUSE -dQUIET -dBATCH -sOutputFile=${finalOut} ${tmpOut}`,
       { stdio: "inherit" },
     );
     fs.unlinkSync(tmpOut);

--- a/scripts/get-pdf.js
+++ b/scripts/get-pdf.js
@@ -9,16 +9,79 @@ const getPdf = async () => {
       "--no-sandbox",
       "--disable-setuid-sandbox",
       "--disable-dev-shm-usage",
-      "--disable-accelerated-2d-canvas",
       "--no-first-run",
       "--no-zygote",
-      "--disable-gpu",
+      // Force the highest quality compositor settings — the warm radial
+      // gradients in the hero/aurora layers band hard when Chrome falls
+      // back to its software rasterizer at low DPI.
+      "--force-color-profile=srgb",
+      "--font-render-hinting=medium",
+      "--disable-lcd-text",
     ],
   });
 
   const page = await browser.newPage();
+  // 2× device scale doubles the underlying raster of every gradient/glow
+  // before Puppeteer rasterizes it into the PDF, which kills banding on
+  // the hero aurora and the pubs-feature glow.
+  await page.setViewport({ width: 1200, height: 800, deviceScaleFactor: 2 });
+  // Keep screen styles in the PDF — Chrome flips to `@media print` for
+  // page.pdf() by default, which can disable background gradients on any
+  // rule guarded by media queries.
+  await page.emulateMediaType("screen");
   await page.goto("https://www.gabrieltaveira.com.br/en-US", {
     waitUntil: "networkidle0",
+  });
+
+  // Decorative animated layers — the button shine sweep, the soundwave
+  // bars, the spark rain — leave artifacts when frozen mid-animation
+  // (the button shine, in particular, sits as a translucent rectangle
+  // off the button's left edge at the start of the keyframe). For PDF
+  // export we hide the moving decoration entirely and keep transitions
+  // disabled so hover-only states never leak through.
+  // Hide moving/transient decoration and disable transitions so hover-only
+  // styling doesn't leak through. The atmospheric gradients (hero bg,
+  // aurora, glows) stay — they're what give the design its warmth.
+  //
+  // Box-shadows with large blur radii rasterize as visible blocks in PDF
+  // at print DPI (the soft shadow becomes a hard-edged rectangle in the
+  // raster grid). Replacing them with `none` keeps the content but kills
+  // the artifact halos around the CTA buttons and other shadowed pills.
+  await page.addStyleTag({
+    content: `
+      /* Components marked .ws-pdf-hide are interactive-only (nav, form,
+         language switcher, live clock, CTA buttons that don't make sense
+         in a static export). Stripped before measuring height. */
+      .ws-pdf-hide { display: none !important; }
+
+      /* When the contact form is stripped the left column would sit in
+         half the grid width. Reflow the contact grid to a single column
+         so the heading and channel list fill the section properly. */
+      .ws-contact-grid { grid-template-columns: 1fr !important; }
+
+      .ws-btn-primary::after,
+      .ws-pubs-bars,
+      .ws-flourish-spark .ws-spark-glow,
+      .ws-toast,
+      #ws-toast-root,
+      .ws-stars,
+      .ws-shelf-edge { display: none !important; }
+
+      .ws-hero-aurora,
+      .ws-pubs-feature-glow,
+      .ws-writing-callout-glow,
+      .ws-nav-brand-burst::after { animation: none !important; transform: none !important; }
+
+      /* Strip every box-shadow site-wide for the export. Soft drop and
+         inner shadows are what rasterize as hard rectangular halos in
+         the PDF — the design still reads without them. */
+      *, *::before, *::after { box-shadow: none !important; }
+      .ws-chip-dot,
+      .ws-hero-eyebrow-dot,
+      .ws-hero-status-dot { filter: none !important; }
+
+      *, *::before, *::after { transition: none !important; }
+    `,
   });
 
   // Wait until every hero stat has rendered its final number — the count-up

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,10 +1,79 @@
+import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
+
+import { Analytics } from "@vercel/analytics/react";
+import { GoogleTagManager } from "@next/third-parties/google";
+
+import { buildPortfolioJsonLd } from "@/components/portfolio/structured-data";
 import { routing } from "@/utils/routing";
+
+const SITE_URL = "https://gabrieltaveira.dev";
+const GTM_ID = "G-1S8PR4TDYM";
+
+/**
+ * Dense, ATS-friendly description. Packs role, tenure, stack and location into
+ * one sentence while staying under 160 characters for SERP truncation.
+ */
+const DESCRIPTION =
+  "Gabriel Taveira — Engineering Lead with 9+ years in React Native, Expo and mobile architecture. Brazil-based (Ribeirão Preto), remote with US teams.";
+
+const TITLE = "Gabriel Taveira · Engineering Lead";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+
+  const languages: Record<string, string> = {
+    "x-default": `${SITE_URL}/${routing.defaultLocale}`,
+  };
+  for (const l of routing.locales) {
+    languages[l] = `${SITE_URL}/${l}`;
+  }
+
+  return {
+    title: TITLE,
+    description: DESCRIPTION,
+    authors: [{ name: "Gabriel Taveira", url: SITE_URL }],
+    creator: "Gabriel Taveira",
+    publisher: "Gabriel Taveira",
+    alternates: {
+      canonical: `${SITE_URL}/${locale}`,
+      languages,
+      types: {
+        "application/pdf": [
+          { url: "/curriculum.pdf", title: "Resume PDF" },
+        ],
+      },
+    },
+    openGraph: {
+      type: "profile",
+      url: `${SITE_URL}/${locale}`,
+      siteName: "Gabriel Taveira",
+      title: TITLE,
+      description: DESCRIPTION,
+      locale: locale.replace("-", "_"),
+      images: ["/og-image.png"],
+      firstName: "Gabriel",
+      lastName: "Taveira",
+      username: "gabrieltaveira",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: TITLE,
+      description: DESCRIPTION,
+      images: ["/og-image.png"],
+      creator: "@gabrieltaveira",
+    },
+  };
 }
 
 export default async function LocaleLayout({
@@ -19,9 +88,37 @@ export default async function LocaleLayout({
     notFound();
   }
   const messages = await getMessages();
+  const { person, profilePage } = buildPortfolioJsonLd(locale);
+
   return (
-    <NextIntlClientProvider messages={messages} locale={locale}>
-      {children}
-    </NextIntlClientProvider>
+    <html lang={locale}>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Caveat:wght@500;600&family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&display=swap"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(person) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(profilePage) }}
+        />
+      </head>
+      <GoogleTagManager gtmId={GTM_ID} />
+      <Analytics />
+      <body>
+        <NextIntlClientProvider messages={messages} locale={locale}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
+    </html>
   );
 }

--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -6,6 +6,19 @@
 
 * { box-sizing: border-box; }
 
+/* Visually hide content but keep it discoverable for screen readers and
+   resume parsers. Used to expose semantic <address>, alt employer names,
+   etc. that the visual design doesn't show as plain text. */
+.ws-sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html, body {
   overflow-x: clip;
 }
@@ -274,7 +287,6 @@ a.ws-nav-link, a.ws-nav-link:hover {
   margin: 0;
   padding-left: 24px; padding-right: 24px;
   position: relative;
-  overflow: clip;
 }
 .ws-hero-bg {
   position: absolute; inset: 0;

--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -6,12 +6,14 @@
 
 * { box-sizing: border-box; }
 
+html, body {
+  overflow-x: clip;
+}
 body {
   margin: 0;
   background: var(--ink-900);
   color: var(--color-fg);
   font-family: var(--font-sans);
-  overflow-x: hidden;
 }
 
 /* Site-wide ambient background · a faint warm radial from top-left */
@@ -272,6 +274,7 @@ a.ws-nav-link, a.ws-nav-link:hover {
   margin: 0;
   padding-left: 24px; padding-right: 24px;
   position: relative;
+  overflow: clip;
 }
 .ws-hero-bg {
   position: absolute; inset: 0;
@@ -464,21 +467,32 @@ a.ws-nav-link, a.ws-nav-link:hover {
   white-space: nowrap;
   z-index: 2;
 }
+/* Sideways arrow ("←") works when the marginalia floats to the right of the
+   digit on desktop; on mobile it sits below the stat so an upward arrow
+   ("↑") reads more naturally. */
+.ws-hero-stat-tag-arrow-up { display: none; }
 @media (max-width: 720px) {
-  /* On the 2-col mobile grid, sit just under the digit (above the label)
-     so it still reads as pointing at the 56 without colliding with the
-     neighbor column. */
+  /* On the 2-col mobile grid, tuck the marginalia under the label so it
+     reads as pointing at the 56 without spilling into the neighbor column
+     or past the viewport edge on small phones. */
   .ws-hero-stat-tag {
-    position: absolute;
-    top: 0.85em;
-    left: 50%;
-    transform: translate(50%, 8px);
+    position: static;
+    display: block;
+    text-align: center;
+    /* Nudge right so the upward arrow points at the digit's optical
+       center rather than landing under the leading edge of the label. */
+    padding-left: 4.5em;
+    margin-top: 4px;
+    transform: none;
+    white-space: normal;
   }
   .ws-hero-stat-tag .ws-marginalia {
     /* The default rule hides .ws-marginalia below 640px — override here
        so the tag stays visible when it's the whole point of the stat. */
     display: inline-block;
   }
+  .ws-hero-stat-tag-arrow-side { display: none; }
+  .ws-hero-stat-tag-arrow-up { display: inline; }
 }
 
 /* Stars + shelf edge */
@@ -820,8 +834,17 @@ a.ws-nav-link, a.ws-nav-link:hover {
   color: var(--ember-300);
   font-weight: 600;
 }
+.ws-work-cell .ws-eyebrow-token-date { color: var(--ink-400); font-weight: 500; }
 .ws-work-cell .ws-eyebrow-sep {
   color: var(--ink-500);
+}
+@media (max-width: 720px) {
+  /* On narrow viewports the meta line wraps unpredictably (e.g. "A.TEAM ·
+     D-ID · 2023 →" leaving "25" orphaned). Force the date token to a new
+     line so every card reads as "company(ies) on top, date below". */
+  .ws-work-cell .ws-eyebrow { display: block; }
+  .ws-work-cell .ws-eyebrow-sep-date { display: none; }
+  .ws-work-cell .ws-eyebrow-token-date { display: block; margin-top: 2px; }
 }
 .ws-work-cell-title {
   font-family: var(--font-display); font-size: 24px; font-weight: 400;
@@ -854,6 +877,17 @@ a.ws-nav-link, a.ws-nav-link:hover {
   transition: gap var(--dur-fast), color var(--dur-fast);
 }
 .ws-work-cell:hover .ws-work-cell-cta { gap: 10px; color: var(--ember-300); }
+@media (max-width: 720px) {
+  /* Cards wrap inconsistently on narrow viewports — sometimes the CTA fits
+     next to the tags, sometimes it drops. Force a single layout: tags on
+     top, CTA on its own row below, every card. */
+  .ws-work-cell-foot {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+  .ws-work-cell-tags { width: 100%; }
+}
 
 /* Flourishes — sized to fit inside .ws-work-cell-flourish (130×44 zone) */
 .ws-flourish {
@@ -864,7 +898,8 @@ a.ws-nav-link, a.ws-nav-link:hover {
 
 /* Ticker */
 .ws-flourish-ticker {
-  flex-direction: column; align-items: flex-end; gap: 2px;
+  flex-direction: column; align-items: flex-end; justify-content: flex-start;
+  gap: 6px;
   color: var(--ember-400);
 }
 .ws-ticker-row {
@@ -879,7 +914,7 @@ a.ws-nav-link, a.ws-nav-link:hover {
 .ws-ticker-label { color: var(--ink-400); }
 .ws-ticker-price { color: var(--ember-300); }
 .ws-ticker-delta { color: var(--teal-300); }
-.ws-ticker-chart { width: 100%; height: 14px; opacity: 0.8; }
+.ws-ticker-chart { width: 80%; height: 10px; opacity: 0.75; }
 
 /* Frames */
 .ws-flourish-frames {
@@ -1223,9 +1258,28 @@ a.ws-nav-link, a.ws-nav-link:hover {
 }
 .ws-pubs-feature-meta { display: flex; align-items: center; gap: 16px; position: relative; flex-wrap: wrap; }
 .ws-pubs-feature-meta .ws-chip { white-space: nowrap; }
-.ws-pubs-bars { display: flex; align-items: flex-end; gap: 3px; height: 22px; }
-.ws-pubs-bar { width: 3px; background: var(--ember-400); border-radius: 1px; height: 6px; animation: ws-bars 1.2s ease-in-out infinite; box-shadow: 0 0 6px rgba(224,122,31,0.6); }
-@keyframes ws-bars { 0%, 100% { height: 4px; } 50% { height: 22px; } }
+.ws-pubs-bars {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 24px;
+}
+.ws-pubs-bar {
+  width: 2.5px;
+  background: var(--ember-400);
+  border-radius: 999px;
+  /* Per-bar base/peak heights are injected via CSS custom props so each
+     bar gets its own envelope and timing — together they read as natural
+     voice energy rather than a synchronized equalizer demo. */
+  height: var(--bar-base, 4px);
+  animation: ws-bars 1s ease-in-out infinite alternate;
+  box-shadow: 0 0 6px rgba(224,122,31,0.55);
+  will-change: height;
+}
+@keyframes ws-bars {
+  from { height: var(--bar-base, 4px); }
+  to   { height: var(--bar-peak, 22px); }
+}
 .ws-pubs-feature-title {
   position: relative;
   font-family: var(--font-display); font-weight: 400;
@@ -1272,9 +1326,11 @@ a.ws-nav-link, a.ws-nav-link:hover {
 .ws-pubs-card h4 {
   grid-column: 1 / 2;
   font-family: var(--font-display); font-weight: 400;
-  font-size: 20px; letter-spacing: -0.012em;
+  font-size: clamp(16px, 4.6vw, 20px); letter-spacing: -0.012em;
   color: var(--ink-50); margin: 4px 0 4px;
   line-height: 1.32;
+  /* Long URL-style handles must wrap rather than push the card wider. */
+  overflow-wrap: anywhere;
 }
 .ws-pubs-card p {
   grid-column: 1 / 2;
@@ -1544,22 +1600,61 @@ a.ws-nav-link, a.ws-nav-link:hover {
 .ws-footer { margin-top: 96px; padding: 24px 0 8px; border-top: 1px solid var(--color-divider); }
 .ws-footer-row { display: flex; align-items: center; gap: 24px; font-family: var(--font-mono); font-size: 11px; color: var(--ink-400); text-transform: uppercase; letter-spacing: 0.10em; flex-wrap: wrap; }
 .ws-footer-spacer { flex: 1; }
+.ws-footer-end {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  /* Claim a full row so the language switcher and the signature can sit on
+     opposite edges of the footer, rather than huddling together once the
+     row wraps below the meta line. */
+  flex: 1 1 100%;
+  justify-content: space-between;
+}
 @media (max-width: 720px) {
-  /* On narrow viewports the footer row wraps, leaving the brand mark
-     orphaned on its own line above the meta. Hide it on mobile — the
-     meta line already includes the name. */
-  .ws-footer-row > .ws-brand { display: none; }
+  /* On mobile the footer becomes a tight two-row signature, not a six-row
+     poster: drop the brand mark and the "building & breaking..." tagline
+     (both already echoed elsewhere on the page), keep one meta line for
+     identity, and pair the language switcher with the marginalia on the
+     same row so the whole footer reads as one balanced unit. */
+  .ws-footer { margin-top: 48px; padding: 18px 0 20px; }
+  .ws-footer-row > .ws-brand,
+  .ws-footer-row > .ws-footer-meta + .ws-footer-spacer + .ws-footer-meta { display: none; }
+  .ws-footer-row {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 14px;
+    font-size: 9.5px;
+    letter-spacing: 0.14em;
+  }
+  .ws-footer-spacer { display: none; }
+  .ws-footer-row > .ws-footer-meta {
+    color: var(--ink-500);
+    line-height: 1.55;
+  }
+  /* Marginalia on the left, language switcher on the right — feels lighter
+     than a chunky pill anchoring the bottom of the column. */
+  .ws-footer-end {
+    width: 100%;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+  }
+  .ws-footer-marginalia .ws-marginalia {
+    font-size: 13px;
+    opacity: 0.7;
+  }
 }
 .ws-footer-marginalia {
   display: inline-flex;
   align-items: center;
+  margin-left: auto;
 }
 @media (max-width: 720px) {
-  /* On narrow viewports the footer rows wrap to multiple lines; keep the
-     marginalia compact and aligned to the right rather than full-width. */
+  /* In the centered mobile stack, let the marginalia sit on its own row
+     centered like the rest — the desktop "anchored right" position only
+     makes sense when the row is one line. */
   .ws-footer-marginalia {
-    width: 100%;
-    justify-content: flex-end;
+    margin-left: 0;
   }
 }
 @media (max-width: 640px) {
@@ -1723,6 +1818,7 @@ body.ws-crt::after {
   .ws-hero-status-meta { display: none; }
   .ws-work-grid { grid-template-columns: 1fr; }
   .ws-pubs-grid { grid-template-columns: 1fr; }
+  .ws-pubs-card { padding: 18px; gap: 4px 10px; }
   .ws-awards { grid-template-columns: 1fr 1fr; }
   .ws-now-grid { grid-template-columns: 1fr; }
   .ws-now-card-lead { grid-row: auto; }
@@ -1730,7 +1826,6 @@ body.ws-crt::after {
   .ws-talks-row, .ws-writing-row { grid-template-columns: 1fr; gap: 6px; padding: 18px 4px; }
   .ws-nav-links { display: none; }
   .ws-form-foot { flex-direction: column; align-items: flex-start; }
-  .ws-flourish-ticker, .ws-flourish-frames, .ws-flourish-scoot { display: none; }
 }
 
 /* =========================================================================

--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -6,6 +6,12 @@
 
 * { box-sizing: border-box; }
 
+/* Marker class for elements that are interactive-only and have no place
+   in the static PDF export (live clock, interactive form, language
+   toggle, sticky nav, etc.). The puppeteer script in scripts/get-pdf.js
+   strips these from the rendered DOM before exporting. */
+.ws-pdf-hide {}
+
 /* Visually hide content but keep it discoverable for screen readers and
    resume parsers. Used to expose semantic <address>, alt employer names,
    etc. that the visual design doesn't show as plain text. */
@@ -1177,17 +1183,9 @@ a.ws-nav-link, a.ws-nav-link:hover {
 .ws-writing-topic-brass { background: rgba(200,154,58,0.10); border-color: rgba(200,154,58,0.35); color: var(--brass-300); }
 .ws-writing-topic-teal  { background: rgba(42,163,155,0.10); border-color: rgba(42,163,155,0.30); color: var(--teal-300); }
 .ws-writing-callout-cta { position: relative; z-index: 1; }
-.ws-writing-callout-link {
-  display: inline-flex; align-items: center; gap: 8px;
-  font-family: var(--font-sans); font-size: 14px; font-weight: 500;
-  background: var(--ember-500); color: var(--ink-1000);
-  padding: 14px 22px;
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-ember), inset 0 1px 0 rgba(255,255,255,0.28);
-  transition: background var(--dur-fast);
-  white-space: nowrap;
-}
-.ws-writing-callout:hover .ws-writing-callout-link { background: var(--ember-400); }
+/* Hover state propagated from the callout link so the button reacts to
+   the parent <a>, not just direct cursor target. */
+.ws-writing-callout:hover .ws-btn-primary { background: var(--ember-400); }
 
 /* Legacy writing list (kept for reference if reactivated) */
 .ws-writing { display: flex; flex-direction: column; }

--- a/src/app/design-tokens.css
+++ b/src/app/design-tokens.css
@@ -3,8 +3,8 @@
    Foundation tokens: color + type
    ============================================================================= */
 
-/* ----- Webfonts ----- */
-@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&display=swap');
+/* Webfonts are imported in globals.css so the @import sits before all
+   other CSS rules (Turbopack/PostCSS requirement). */
 
 :root {
   /* =========================================================================

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&display=swap');
 @import "tailwindcss";
 @import "./design-tokens.css";
 @import "./design-portfolio.css";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,39 +1,19 @@
 import "@total-typescript/ts-reset";
 import "./globals.css";
 
-import { Analytics } from "@vercel/analytics/react";
-import { GoogleTagManager } from "@next/third-parties/google";
+import type { Metadata } from "next";
 
-export const metadata = {
+/**
+ * Root layout. The `<html>` and `<body>` shells live in
+ * `src/app/[locale]/layout.tsx` so that `<html lang>` reflects the active
+ * locale. Next 16 accepts a pass-through root layout when a nested layout
+ * supplies the document shell.
+ */
+
+export const metadata: Metadata = {
   metadataBase: new URL("https://gabrieltaveira.dev"),
-  title: "Gabriel Taveira · Engineering Lead",
-  description:
-    "Gabriel Taveira — Engineering Lead. Building and breaking systems since age 8.",
-  openGraph: {
-    images: ["./og-image.png"],
-  },
 };
 
-const GTM_ID = "G-1S8PR4TDYM";
-
 export default function RootLayout({ children }: React.PropsWithChildren) {
-  return (
-    <html lang="en">
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Caveat:wght@500;600&family=Bricolage+Grotesque:opsz,wdth,wght@12..96,75..100,200..800&display=swap"
-        />
-      </head>
-      <GoogleTagManager gtmId={GTM_ID} />
-      <Analytics />
-      <body>{children}</body>
-    </html>
-  );
+  return children;
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://gabrieltaveira.dev";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+
+import { routing } from "@/utils/routing";
+
+const SITE_URL = "https://gabrieltaveira.dev";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const routes: MetadataRoute.Sitemap = [];
+
+  const languages = (path: string) =>
+    Object.fromEntries(
+      routing.locales.map((l) => [l, `${SITE_URL}/${l}${path}`]),
+    );
+
+  for (const locale of routing.locales) {
+    routes.push({
+      url: `${SITE_URL}/${locale}`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: locale === routing.defaultLocale ? 1 : 0.8,
+      alternates: { languages: languages("") },
+    });
+    routes.push({
+      url: `${SITE_URL}/${locale}/links`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.6,
+      alternates: { languages: languages("/links") },
+    });
+  }
+
+  return routes;
+}

--- a/src/components/portfolio/Awards.tsx
+++ b/src/components/portfolio/Awards.tsx
@@ -1,3 +1,4 @@
+import Balancer from "react-wrap-balancer";
 import { getTranslations } from "next-intl/server";
 import { AWARDS } from "./data";
 import { Eyebrow, richTags } from "./Shared";
@@ -9,7 +10,7 @@ export async function Awards() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow")}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
         <p className="ws-section-sub">{t("sub")}</p>
       </div>

--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -127,10 +127,12 @@ export function Contact() {
           <span className="ws-footer-meta">{t("footerMeta")}</span>
           <span className="ws-footer-spacer" />
           <span className="ws-footer-meta">{t("footerTag")}</span>
-          <LanguageSwitcher />
-          <span className="ws-footer-marginalia">
-            <Marginalia tilt={-3}>{tMarg("madeWith")}</Marginalia>
-          </span>
+          <div className="ws-footer-end">
+            <LanguageSwitcher />
+            <span className="ws-footer-marginalia">
+              <Marginalia tilt={-3}>{tMarg("madeWith")}</Marginalia>
+            </span>
+          </div>
         </div>
       </footer>
     </section>

--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -58,7 +58,7 @@ export function Contact() {
           </div>
         </div>
 
-        <form className="ws-contact-form" onSubmit={submit}>
+        <form className="ws-contact-form ws-pdf-hide" onSubmit={submit}>
           {sent ? (
             <div className="ws-contact-sent">
               <Chip tone="ember">Sent</Chip>
@@ -122,7 +122,7 @@ export function Contact() {
         </form>
       </div>
 
-      <footer className="ws-footer">
+      <footer className="ws-footer ws-pdf-hide">
         <address className="ws-sr-only">
           Gabriel Taveira, Engineering Lead. Ribeirão Preto, SP, Brazil.
           Reach out via{" "}

--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import Balancer from "react-wrap-balancer";
 import { useTranslations } from "next-intl";
 import { CHANNELS } from "./data";
 import { Marginalia } from "./Marginalia";
@@ -36,7 +37,7 @@ export function Contact() {
         <div className="ws-contact-left">
           <Eyebrow accent>{t("eyebrow")}</Eyebrow>
           <h2 className="ws-contact-title">
-            {t.rich("title", richTags)}
+            <Balancer>{t.rich("title", richTags)}</Balancer>
           </h2>
           <p className="ws-contact-sub">{t("sub")}</p>
           <div className="ws-contact-channels">
@@ -122,6 +123,12 @@ export function Contact() {
       </div>
 
       <footer className="ws-footer">
+        <address className="ws-sr-only">
+          Gabriel Taveira, Engineering Lead. Ribeirão Preto, SP, Brazil.
+          Reach out via{" "}
+          <a href="mailto:gabrielstaveira@gmail.com">gabrielstaveira@gmail.com</a>
+          .
+        </address>
         <div className="ws-footer-row">
           <BrandMark size={18} withText={false} />
           <span className="ws-footer-meta">{t("footerMeta")}</span>

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -119,14 +119,6 @@ export function Hero({ onContact }: { onContact: () => void }) {
           </a>
         </div>
 
-        <div className="ws-hero-status">
-          <span className="ws-eyebrow">{t("currently")}</span>
-          <span className="ws-hero-status-sep">·</span>
-          <span className="ws-hero-status-co">{t("consulting")}</span>
-          <span className="ws-hero-status-sep">·</span>
-          <span className="ws-hero-status-meta">{t("location")}</span>
-        </div>
-
         <div className="ws-hero-stats">
           <div ref={yearsRef} className="ws-hero-stat">
             <div className="ws-hero-stat-glow ws-hero-stat-glow-ember" />
@@ -145,7 +137,11 @@ export function Hero({ onContact }: { onContact: () => void }) {
             <div className="ws-hero-stat-l">{tStats("reports")}</div>
             <div className="ws-hero-stat-meta">{tStats("reportsMeta")}</div>
             <span className="ws-hero-stat-tag">
-              <Marginalia tilt={-6}>{tMarg("yesReally")}</Marginalia>
+              <Marginalia tilt={-6}>
+                <span className="ws-hero-stat-tag-arrow-side" aria-hidden>← </span>
+                <span className="ws-hero-stat-tag-arrow-up" aria-hidden>↑ </span>
+                {tMarg("yesReally")}
+              </Marginalia>
             </span>
           </div>
           <div ref={tinkerRef} className="ws-hero-stat">

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -39,8 +39,8 @@ export function Hero({ onContact }: { onContact: () => void }) {
       <div className="ws-hero-inner">
         <span className="ws-hero-eyebrow">
           <span className="ws-eyebrow ws-eyebrow-accent">{t("role")}</span>
-          <span className="ws-eyebrow-sep">·</span>
-          <span className="ws-eyebrow" id="ws-clock" />
+          <span className="ws-eyebrow-sep ws-pdf-hide">·</span>
+          <span className="ws-eyebrow ws-pdf-hide" id="ws-clock" />
         </span>
 
         <h1 className="ws-hero-title">
@@ -67,7 +67,7 @@ export function Hero({ onContact }: { onContact: () => void }) {
         <div className="ws-hero-cta-row">
           <button
             type="button"
-            className="ws-btn ws-btn-primary"
+            className="ws-btn ws-btn-primary ws-pdf-hide"
             onClick={onContact}
           >
             {t("getInTouch")}
@@ -96,7 +96,7 @@ export function Hero({ onContact }: { onContact: () => void }) {
             {t("viewLinkedIn")}
           </a>
           <a
-            className="ws-btn ws-btn-ghost"
+            className="ws-btn ws-btn-ghost ws-pdf-hide"
             href={CURRICULUM_PDF}
             target="_blank"
             rel="noreferrer"

--- a/src/components/portfolio/LanguageSwitcher.tsx
+++ b/src/components/portfolio/LanguageSwitcher.tsx
@@ -9,7 +9,7 @@ export function LanguageSwitcher() {
   const pathname = usePathname(); // locale-stripped pathname
 
   return (
-    <nav className="ws-lang-switch" aria-label="Language">
+    <nav className="ws-lang-switch ws-pdf-hide" aria-label="Language">
       {routing.locales.map((locale) => {
         const label = locale === "en-US" ? "EN" : "PT";
         const isActive = locale === current;

--- a/src/components/portfolio/Nav.tsx
+++ b/src/components/portfolio/Nav.tsx
@@ -35,7 +35,7 @@ export function Nav({
   };
 
   return (
-    <div className={`ws-nav-wrap${scrolled ? " ws-nav-scrolled" : ""}`}>
+    <div className={`ws-nav-wrap ws-pdf-hide${scrolled ? " ws-nav-scrolled" : ""}`}>
       <nav className="ws-nav">
         <a
           className={"ws-nav-brand" + (burst ? " ws-nav-brand-burst" : "")}

--- a/src/components/portfolio/NowPlaying.tsx
+++ b/src/components/portfolio/NowPlaying.tsx
@@ -1,3 +1,4 @@
+import Balancer from "react-wrap-balancer";
 import { getLocale, getTranslations } from "next-intl/server";
 import { NOW } from "./data";
 import { currentMonthLabel } from "./lifeline";
@@ -14,7 +15,7 @@ export async function NowPlaying() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow", { date: monthLabel })}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
       </div>
       <ul className="ws-now-list">

--- a/src/components/portfolio/Publications.tsx
+++ b/src/components/portfolio/Publications.tsx
@@ -1,3 +1,4 @@
+import Balancer from "react-wrap-balancer";
 import { getTranslations } from "next-intl/server";
 import { MEDIUM, SPACE_CAST, SPACE_CAST_PLAYLIST, SPACE_SQUAD } from "./data";
 import { Marginalia } from "./Marginalia";
@@ -11,7 +12,7 @@ export async function Publications() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow")}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
       </div>
 
@@ -53,8 +54,10 @@ export async function Publications() {
             </div>
           </div>
           <h3 className="ws-pubs-feature-title">
-            {t.rich("featureTitle", richTags)}
-            <Marginalia tilt={5}>{tMarg("spaceCastSeason")}</Marginalia>
+            <Balancer>
+              {t.rich("featureTitle", richTags)}
+              <Marginalia tilt={5}>{tMarg("spaceCastSeason")}</Marginalia>
+            </Balancer>
           </h3>
           <p className="ws-pubs-feature-sub">{t("featureSub")}</p>
           <div className="ws-pubs-feature-cta">

--- a/src/components/portfolio/Publications.tsx
+++ b/src/components/portfolio/Publications.tsx
@@ -24,13 +24,32 @@ export async function Publications() {
               {t("onAir")}
             </span>
             <div className="ws-pubs-bars" aria-hidden="true">
-              {Array.from({ length: 18 }).map((_, i) => (
-                <span
-                  key={i}
-                  className="ws-pubs-bar"
-                  style={{ animationDelay: `${(i % 6) * 90}ms` }}
-                />
-              ))}
+              {Array.from({ length: 22 }).map((_, i) => {
+                // Tapered envelope — middle bars peak taller than the edges,
+                // mimicking the energy curve of a spoken phrase. Each bar
+                // also gets a deterministic phase + duration jitter so they
+                // don't sweep in a single wave.
+                const n = 22;
+                const t = i / (n - 1);
+                const envelope = Math.sin(t * Math.PI);
+                const jitter = ((i * 9301 + 49297) % 233) / 233;
+                const peak = 6 + envelope * 14 + jitter * 6;
+                const base = 2 + jitter * 2;
+                const delay = ((i * 53) % 900) - 200;
+                const duration = 800 + ((i * 137) % 600);
+                return (
+                  <span
+                    key={i}
+                    className="ws-pubs-bar"
+                    style={{
+                      ["--bar-base" as string]: `${base.toFixed(1)}px`,
+                      ["--bar-peak" as string]: `${peak.toFixed(1)}px`,
+                      animationDelay: `${delay}ms`,
+                      animationDuration: `${duration}ms`,
+                    }}
+                  />
+                );
+              })}
             </div>
           </div>
           <h3 className="ws-pubs-feature-title">

--- a/src/components/portfolio/TalksList.tsx
+++ b/src/components/portfolio/TalksList.tsx
@@ -1,3 +1,4 @@
+import Balancer from "react-wrap-balancer";
 import { getTranslations } from "next-intl/server";
 import { TALKS } from "./data";
 import { ArrowUpRight, Eyebrow, richTags } from "./Shared";
@@ -10,7 +11,7 @@ export async function TalksList() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow")}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
         <p className="ws-section-sub">{t("sub")}</p>
       </div>

--- a/src/components/portfolio/WorkGrid.tsx
+++ b/src/components/portfolio/WorkGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import Balancer from "react-wrap-balancer";
 import { useTranslations } from "next-intl";
 import { WORK, type WorkItem } from "./data";
 import { Flourish } from "./Flourishes";
@@ -80,7 +81,7 @@ function WorkTile({ item }: { item: WorkItem }) {
       <div className="ws-work-cell-top">
         <HighlightedEyebrow text={item.eyebrow} />
       </div>
-      <h3 className="ws-work-cell-title">{t("title")}</h3>
+      <h3 className="ws-work-cell-title"><Balancer>{t("title")}</Balancer></h3>
       <p className="ws-work-cell-blurb">
         {t.rich("blurb", {
           mark: (chunks: ReactNode) => <Mark>{chunks}</Mark>,
@@ -107,7 +108,7 @@ export function WorkGrid() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow")}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
         <p className="ws-section-sub">{t("sub")}</p>
       </div>

--- a/src/components/portfolio/WorkGrid.tsx
+++ b/src/components/portfolio/WorkGrid.tsx
@@ -9,14 +9,32 @@ import { ArrowUpRight, Eyebrow, richTags, Tag } from "./Shared";
 
 function HighlightedEyebrow({ text }: { text: string }) {
   const parts = text.split(" · ");
+  const lastIdx = parts.length - 1;
   return (
     <span className="ws-eyebrow">
-      {parts.map((part, i) => (
-        <Fragment key={i}>
-          {i > 0 && <span className="ws-eyebrow-sep"> · </span>}
-          <span className="ws-eyebrow-token">{part}</span>
-        </Fragment>
-      ))}
+      {parts.map((part, i) => {
+        const isDate = i === lastIdx;
+        return (
+          <Fragment key={i}>
+            {i > 0 && (
+              <span
+                className={
+                  "ws-eyebrow-sep" + (isDate ? " ws-eyebrow-sep-date" : "")
+                }
+              >
+                {" · "}
+              </span>
+            )}
+            <span
+              className={
+                "ws-eyebrow-token" + (isDate ? " ws-eyebrow-token-date" : "")
+              }
+            >
+              {part}
+            </span>
+          </Fragment>
+        );
+      })}
     </span>
   );
 }

--- a/src/components/portfolio/WritingList.tsx
+++ b/src/components/portfolio/WritingList.tsx
@@ -1,3 +1,4 @@
+import Balancer from "react-wrap-balancer";
 import { getTranslations } from "next-intl/server";
 import { MEDIUM, WRITING_TOPICS } from "./data";
 import { ArrowUpRight, Eyebrow, richTags } from "./Shared";
@@ -9,7 +10,7 @@ export async function WritingList() {
       <div className="ws-section-head">
         <Eyebrow>{t("eyebrow")}</Eyebrow>
         <h2 className="ws-section-title">
-          {t.rich("title", richTags)}
+          <Balancer>{t.rich("title", richTags)}</Balancer>
         </h2>
         <p className="ws-section-sub">{t("sub")}</p>
       </div>
@@ -39,7 +40,7 @@ export async function WritingList() {
             <span>{t("handle")}</span>
           </div>
           <h3 className="ws-writing-callout-title">
-            {t.rich("calloutTitle", richTags)}
+            <Balancer>{t.rich("calloutTitle", richTags)}</Balancer>
           </h3>
           <p className="ws-writing-callout-sub">{t("calloutSub")}</p>
           <div className="ws-writing-topics">

--- a/src/components/portfolio/WritingList.tsx
+++ b/src/components/portfolio/WritingList.tsx
@@ -55,7 +55,7 @@ export async function WritingList() {
           </div>
         </div>
         <div className="ws-writing-callout-cta">
-          <span className="ws-writing-callout-link">
+          <span className="ws-btn ws-btn-primary">
             {t("readOnMedium")} <ArrowUpRight size={18} />
           </span>
         </div>

--- a/src/components/portfolio/index.tsx
+++ b/src/components/portfolio/index.tsx
@@ -1,3 +1,4 @@
+import { Provider as BalancerProvider } from "react-wrap-balancer";
 import { Awards } from "./Awards";
 import { ClientChrome } from "./ClientChrome";
 import { Contact } from "./Contact";
@@ -13,10 +14,14 @@ import { WritingList } from "./WritingList";
  * browser-only behavior is itself a server component, so the full editorial
  * copy is in the initial HTML for SEO. `ClientChrome` injects the sticky
  * Nav and the global keyboard/easter-egg behavior.
+ *
+ * `<BalancerProvider>` from react-wrap-balancer wraps the tree so any
+ * `<Balancer>` used inside a heading shares a single inline script for
+ * line-balancing measurements.
  */
 export function Portfolio() {
   return (
-    <>
+    <BalancerProvider>
       <ClientChrome />
       <Hero />
       <WorkGrid />
@@ -26,6 +31,6 @@ export function Portfolio() {
       <WritingList />
       <NowPlaying />
       <Contact />
-    </>
+    </BalancerProvider>
   );
 }

--- a/src/components/portfolio/structured-data.ts
+++ b/src/components/portfolio/structured-data.ts
@@ -1,0 +1,125 @@
+/**
+ * Builds schema.org JSON-LD blobs for the portfolio so ATS, AI parsers,
+ * Google Jobs, LinkedIn, Indeed and friends can ingest the page reliably.
+ *
+ * Pure functions, no React. Consumed by the locale layout and rendered
+ * into the initial HTML via a `<script type="application/ld+json">` tag.
+ */
+
+import {
+  CHANNELS,
+  EMAIL_ADDR,
+  GITHUB,
+  LINKEDIN,
+  MEDIUM,
+  WORK,
+} from "./data";
+import { yearsInIndustry } from "./lifeline";
+
+const SITE_URL = "https://gabrieltaveira.dev";
+const KNOWS_ABOUT_CAP = 15;
+
+/**
+ * Extracts the primary company name from an eyebrow string like
+ * "COINBASE · G2I · 2024 → 25" — first dot-separated token, normalised.
+ */
+function companyNameFromEyebrow(eyebrow: string): string {
+  const first = eyebrow.split("·")[0]?.trim() ?? "";
+  if (!first) return "";
+  // Title-case the all-caps eyebrow (preserves accents like É via locale-lower).
+  return first
+    .toLocaleLowerCase("en-US")
+    .replace(/\b\p{L}/gu, (c) => c.toLocaleUpperCase("en-US"));
+}
+
+/**
+ * Aggregates unique tag tokens across all work items, capped to keep the
+ * structured payload lean for crawlers.
+ */
+function knowsAboutFromWork(): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const item of WORK) {
+    for (const tag of item.tags) {
+      if (seen.has(tag)) continue;
+      seen.add(tag);
+      ordered.push(tag);
+      if (ordered.length >= KNOWS_ABOUT_CAP) return ordered;
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Each work item becomes an Organization. We dedupe by name + url so that
+ * multiple stints at the same company (or via the same agency) don't repeat.
+ */
+function worksForFromWork(): Array<{
+  "@type": "Organization";
+  name: string;
+  url: string;
+}> {
+  const out: Array<{ "@type": "Organization"; name: string; url: string }> = [];
+  const seen = new Set<string>();
+  for (const item of WORK) {
+    const name = companyNameFromEyebrow(item.eyebrow);
+    if (!name) continue;
+    const key = `${name}|${item.href}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ "@type": "Organization", name, url: item.href });
+  }
+  return out;
+}
+
+function emailFromChannels(): string | undefined {
+  const email = CHANNELS.find((c) => c.id === "email");
+  if (!email) return undefined;
+  return EMAIL_ADDR;
+}
+
+export type PortfolioJsonLd = {
+  person: Record<string, unknown>;
+  profilePage: Record<string, unknown>;
+};
+
+export function buildPortfolioJsonLd(locale: string): PortfolioJsonLd {
+  const years = yearsInIndustry();
+  const localeUrl = `${SITE_URL}/${locale}`;
+
+  const person: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Gabriel Taveira",
+    givenName: "Gabriel",
+    familyName: "Taveira",
+    jobTitle: "Engineering Lead",
+    description: `Engineering Lead with ${years}+ years building React Native, Expo, and design-system-driven mobile platforms; leads remote teams shipping for Coinbase, Meta/Kustomer, D-ID and AB InBev.`,
+    url: SITE_URL,
+    image: `${SITE_URL}/og-image.png`,
+    sameAs: [LINKEDIN, GITHUB, MEDIUM],
+    worksFor: worksForFromWork(),
+    knowsAbout: knowsAboutFromWork(),
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Ribeirão Preto",
+      addressRegion: "SP",
+      addressCountry: "BR",
+    },
+    nationality: "BR",
+  };
+
+  const email = emailFromChannels();
+  if (email) person.email = `mailto:${email}`;
+
+  const profilePage: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    url: localeUrl,
+    inLanguage: locale,
+    name: "Gabriel Taveira · Engineering Lead",
+    mainEntity: person,
+  };
+
+  return { person, profilePage };
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -217,7 +217,7 @@
     "footerTag": "Building & breaking systems since age 8 · ⚡"
   },
   "marginalia": {
-    "yesReally": "← yes, really",
+    "yesReally": "yes, really",
     "spaceCastSeason": "season 3 ✨",
     "madeWith": "made with ☕ + ⚡ — gt"
   },

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -217,7 +217,7 @@
     "footerTag": "Construindo e desmontando sistemas desde os 8 anos · ⚡"
   },
   "marginalia": {
-    "yesReally": "← é isso mesmo",
+    "yesReally": "é isso mesmo",
     "spaceCastSeason": "temporada 3 ✨",
     "madeWith": "feito com ☕ + ⚡ — gt"
   },


### PR DESCRIPTION
## Summary
- Resolves horizontal overflow on iPhone SE and other narrow viewports (root cause: `body { overflow-x: hidden }` wasn't enough; switched to `overflow-x: clip` on both `html` and `body`, plus `.ws-hero { overflow: clip }`).
- Unblocks the page from rendering entirely: webfont `@import` was sitting after Tailwind's import, which Turbopack/PostCSS rejects (\"@import rules must precede all rules\"). Moved it to the top of \`globals.css\`.
- Removes the standalone \`CURRENTLY · Consulting · …\` hero status pill.
- Repositions the \"yes, really\" marginalia under the 56 stat on mobile with an upward arrow that targets the digit.
- Rebuilds the podcast soundwave as a tapered voice-energy envelope with per-bar jitter (no longer a uniform equalizer).
- Forces consistent work-card layout on mobile: companies on top line, date on its own line; tags on a row, CTA on a row below.
- Rebuilds the footer for narrow viewports: drops the marketing tagline, keeps one meta line, and pairs the language switcher with the made-with signature on a single row using \`justify-content: space-between\`.
- Fixes the PDF export trailing blank page by cropping to the footer's bottom edge + 32px instead of subtracting a fixed 500px; tunes Ghostscript to keep color and gradient quality while shaving size.

## Test plan
- [x] Loaded http://localhost:3000/en-US at 375x667 (iPhone SE) and verified no horizontal scrollbar
- [x] Verified hero status pill removed; \"yes, really\" arrow points up at the 56 on mobile
- [x] Verified all flourishes show consistently across work cards
- [x] Confirmed live Coin API returns accurate data (\$189.44, -3.07%)
- [ ] Verify deployed PDF no longer has trailing blank page (post-merge CI)
- [ ] Verify deployed PDF gradients remain colored and crisp