### PR TITLE
feat(contact): wire form submit to mailto

### DIFF
--- a/src/components/portfolio/Contact.tsx
+++ b/src/components/portfolio/Contact.tsx
@@ -3,7 +3,7 @@
 import { useState, type FormEvent } from "react";
 import Balancer from "react-wrap-balancer";
 import { useTranslations } from "next-intl";
-import { CHANNELS } from "./data";
+import { CHANNELS, EMAIL_ADDR } from "./data";
 import { Marginalia } from "./Marginalia";
 import { ArrowRight, ArrowUpRight, BrandMark, Chip, Eyebrow, richTags } from "./Shared";
 import { SOCIAL_ICONS } from "./SocialIcons";
@@ -28,6 +28,24 @@ export function Contact() {
   const submit = (e: FormEvent) => {
     e.preventDefault();
     if (!form.email || !form.message) return;
+    // Hand off to the user's mail client. Cheaper than running a backend
+    // for the handful of inbound messages this form actually gets, and
+    // the submitter's own SMTP handles delivery + spam reputation.
+    const subjectLine = form.subject?.trim() || "Hi from your portfolio";
+    const body = [
+      form.message,
+      "",
+      "—",
+      form.name ? `From: ${form.name}` : null,
+      form.email ? `Reply: ${form.email}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    const href =
+      `mailto:${EMAIL_ADDR}` +
+      `?subject=${encodeURIComponent(subjectLine)}` +
+      `&body=${encodeURIComponent(body)}`;
+    window.location.href = href;
     setSent(true);
   };
 


### PR DESCRIPTION
## Summary
The contact form's submit handler used to flip to the \"Sent\" view without sending anything. Now it builds a \`mailto:gabrielstaveira@gmail.com\` URL with the subject and body prefilled from the form state and triggers the user's mail client. No backend, no API key, no captcha.

## Test plan
- [x] Fill the form, submit, confirm the default mail app opens with the subject + body prefilled
- [x] Confirm empty email/message still bails out without opening anything