### PR TITLE
fix(copy): drop the playbook tagline

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -33,7 +33,7 @@
   "work": {
     "eyebrow": "Professional Experience · 2017 → now",
     "title": "Teams I've led. Systems that <em>lasted</em>.",
-    "sub": "From four direct reports to fifty-six, across startups, delivery apps, fintechs, and tech giants. Same playbook every time: hire kindly, ship boring tech, write everything down.",
+    "sub": "From four direct reports to fifty-six, across startups, delivery apps, fintechs, and tech giants.",
     "items": {
       "consulting": {
         "title": "Independent consulting",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -33,7 +33,7 @@
   "work": {
     "eyebrow": "Experiência profissional · 2017 → hoje",
     "title": "Times que liderei. Sistemas que <em>ficaram de pé</em>.",
-    "sub": "De quatro reportes diretos a cinquenta e seis, passando por startups, apps de delivery, fintechs e gigantes da tech. Sempre o mesmo método: contratar com critério, entregar tech sem firula, registrar tudo.",
+    "sub": "De quatro reportes diretos a cinquenta e seis, passando por startups, apps de delivery, fintechs e gigantes da tech.",
     "items": {
       "consulting": {
         "title": "Consultoria independente",


### PR DESCRIPTION
Removes the 'Same playbook every time: hire kindly, ship boring tech, write everything down.' sentence from the Work section sub in both en-US and pt-BR.