### PR TITLE
fix(copy): correct ambassador tenure phrasing

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -179,7 +179,7 @@
       "mentoring": {
         "chip": "Mentoring",
         "title": "Space Squad · the next generation",
-        "body": "Ambassador since the program started. The compounding interest on a 20-minute coffee with a junior engineer is wild."
+        "body": "Ambassador in the Space Squad program. The compounding interest on a 20-minute coffee with a junior engineer is wild."
       },
       "tinkering": {
         "chip": "Tinkering",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -179,7 +179,7 @@
       "mentoring": {
         "chip": "Mentoria",
         "title": "Space Squad · a próxima geração",
-        "body": "Embaixador desde o começo do programa. O juros compostos de 20 minutos de café com um júnior é absurdo."
+        "body": "Embaixador no programa Space Squad. O juros compostos de 20 minutos de café com um júnior é absurdo."
       },
       "tinkering": {
         "chip": "Mexendo",


### PR DESCRIPTION
Drops the inaccurate 'since the program started' — I joined as an ambassador but not from day one.