### PR TITLE
fix(work-card): tighten gap between title and blurb

### DIFF
--- a/src/app/design-portfolio.css
+++ b/src/app/design-portfolio.css
@@ -902,12 +902,11 @@ a.ws-nav-link, a.ws-nav-link:hover {
   color: var(--ink-50); margin: 4px 0 0;
   position: relative; z-index: 1;
   padding-right: 80px; /* keep title clear of flourish even after wrap */
-  min-height: 63px; /* reserve 2 lines worth so fallback-font wrap never overlaps blurb */
   text-wrap: pretty;
 }
 .ws-work-cell-blurb {
   font-family: var(--font-sans); font-size: 14px; line-height: 1.55;
-  color: var(--ink-300); margin: 4px 0 0;
+  color: var(--ink-300); margin: 12px 0 0;
   position: relative; z-index: 1;
   text-wrap: pretty;
 }


### PR DESCRIPTION
Removed the 63px min-height reservation on .ws-work-cell-title. It was meant to prevent fallback-font wrap from overlapping the blurb, but for one-line titles it left a huge empty gap. Replaced with a small explicit margin-top on the blurb.