### PR TITLE
chore: stop renovate proposing majors on pnpm overrides

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "The pnpm.overrides block pins patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
+      "matchDepTypes": ["pnpm.overrides"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Renovate has no config in this repo, so it treats the `pnpm.overrides` entries as normal dependencies and keeps opening majors against them. Four so far: `ajv@6` to 8, `@babel/core` to 8, and `brace-expansion@1` and `@2` to 5.

Those entries pin patched releases within a major line. A major bump rewrites what the override means and hands the consumers it was pinning a different API.

`brace-expansion` is the clearest case. v5 moved `module.exports = expand` to a named export, so forcing the 1.x and 2.x consumers onto it breaks minimatch. That is exactly why there are three separate keys, each pinned to its own line.

This disables major updates for that depType only. Patch and minor still come through, so the security pins stay current.