### PR TITLE
chore(deps): pin typescript to <7 until typescript-eslint supports it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchDepTypes": ["pnpm.overrides"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "typescript-eslint reads the JS compiler API for every type-aware rule, and its latest release (8.65.0) still peers on typescript <6.1.0. TypeScript 7 ships only the native compiler and drops that API. Lift this once the peer range allows 7.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
Closing #119 and pinning instead. TypeScript 7 takes typescript-eslint out.

TypeScript 7 is the native Go compiler, and the npm package no longer ships `lib/typescript.js`. Anything that imports the compiler API programmatically breaks, which is what typescript-eslint does for every type-aware rule. 8.65.0, the latest release, still declares `typescript: >=4.8.4 <6.1.0`.

On the #119 branch:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree/dist/create-program/shared.js:59
```

Next 16 handles 7 behind `experimental.useTypeScriptCli`, which shells out to the `tsc` binary instead of importing it. With that flag both `pnpm build` and `tsc --noEmit` pass on 7.

`<7` mirrors the pin in safe-jsx and stops renovate reopening this every week.