### PR TITLE
fix: unbreak tsc and the dead hero contact button

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "get:pdf": "node ./scripts/get-pdf.js",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "lint:fix": "eslint --fix"
   },

--- a/src/components/portfolio/ClientChrome.tsx
+++ b/src/components/portfolio/ClientChrome.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
+  scrollToSection,
   useConsoleBanner,
   useKeyboardEffects,
   useLiveClock,
@@ -46,18 +47,9 @@ export function ClientChrome() {
   );
   useKeyboardEffects(keyboardConfig, setToast);
 
-  const handleNav = useCallback((id: string) => {
-    if (id === "top") {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-      return;
-    }
-    const el = document.getElementById(id);
-    if (el) window.scrollTo({ top: el.offsetTop - 80, behavior: "smooth" });
-  }, []);
-
   return (
     <>
-      <Nav active={active} onNav={handleNav} />
+      <Nav active={active} onNav={scrollToSection} />
       {toast && <Toast {...toast} onClose={() => setToast(null)} />}
       {audit && <SystemAudit onClose={() => setAudit(false)} />}
     </>

--- a/src/components/portfolio/Hero.tsx
+++ b/src/components/portfolio/Hero.tsx
@@ -3,7 +3,7 @@
 import { useRef, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { CURRICULUM_PDF, LINKEDIN } from "./data";
-import { useCountUp } from "./hooks";
+import { scrollToSection, useCountUp } from "./hooks";
 import {
   CAREER_START_YEAR,
   yearsInIndustry,
@@ -13,7 +13,7 @@ import { Marginalia } from "./Marginalia";
 import { Mark } from "./Mark";
 import { ArrowRight, richTags } from "./Shared";
 
-export function Hero({ onContact }: { onContact: () => void }) {
+export function Hero() {
   const t = useTranslations("hero");
   const tStats = useTranslations("hero.stats");
   const tMarg = useTranslations("marginalia");
@@ -68,7 +68,7 @@ export function Hero({ onContact }: { onContact: () => void }) {
           <button
             type="button"
             className="ws-btn ws-btn-primary ws-pdf-hide"
-            onClick={onContact}
+            onClick={() => scrollToSection("contact")}
           >
             {t("getInTouch")}
             <ArrowRight />

--- a/src/components/portfolio/hooks.ts
+++ b/src/components/portfolio/hooks.ts
@@ -78,6 +78,24 @@ export function useCountUp(
   return value;
 }
 
+/** Height of the sticky nav, so a scrolled-to heading isn't hidden under it. */
+const NAV_OFFSET = 80;
+
+/**
+ * Smooth-scrolls to a section by id. `top` goes to the very top of the page
+ * rather than to `#top`'s offset, so the hero's full bleed stays visible.
+ */
+export function scrollToSection(id: string): void {
+  if (id === "top") {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    return;
+  }
+  const el = document.getElementById(id);
+  if (el) {
+    window.scrollTo({ top: el.offsetTop - NAV_OFFSET, behavior: "smooth" });
+  }
+}
+
 /**
  * Tracks which section is currently in view, used to highlight the nav.
  * Returns the section id (mapped: `contact`→`about`, `writing`→`publications`).
@@ -217,12 +235,10 @@ export function useKeyboardEffects(
 
       if (e.key === "/" && !inForm) {
         e.preventDefault();
-        const el = document.getElementById("contact");
         const input = document.querySelector<HTMLInputElement>(
           ".ws-contact-form .ws-input",
         );
-        if (el)
-          window.scrollTo({ top: el.offsetTop - 80, behavior: "smooth" });
+        scrollToSection("contact");
         window.setTimeout(() => input?.focus(), 450);
         return;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
`next.config.ts` says types are checked via `tsc` rather than during the build. No script ran it and nothing in CI called one, so `tsc` has been failing on `tsconfig.json` itself:

```
tsconfig.json(3,15): error TS5107: Option 'target=ES5' is deprecated and will
stop functioning in TypeScript 7.0.
```

`target: es5` never did anything here. Next compiles with SWC and `ignoreBuildErrors` is on, so tsconfig's target only ever fed `tsc`. Set to ES2017, which is what Next writes into `tsconfig.json` on its own when the key is missing.

With `tsc` running again, one real error surfaced:

```
src/components/portfolio/index.tsx(26,8): error TS2741: Property 'onContact' is
missing in type '{}' but required in type '{ onContact: () => void; }'.
```

`Portfolio` renders `<Hero />` with no props, so the hero's "Get in touch" button has had `onClick={undefined}` since it was written. Clicking it does nothing. `Portfolio` is a server component and can't pass a callback down. The scroll now lives in `scrollToSection` in `hooks.ts` and `Hero` calls it directly. `ClientChrome` and the `/` keyboard shortcut each had their own copy of the same `offsetTop - 80` scroll and both use the helper now.

`pnpm build` on this branch, then the hero button clicked in a browser at 1440x900. `window.scrollY` lands on 6318, which is `#contact` `offsetTop` 6398 minus the 80px nav offset.

![hero before the click](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/hero-contact-button-before-click.png)

![contact section after the click](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/hero-contact-button-after-click.png)

The workflow that runs `typecheck` on a PR is #123. `lint` crashes before it lints anything, tracked in #121.