### PR TITLE
ci: typecheck and build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# A new push to the same branch makes the previous run irrelevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup PNPM
+        uses: pnpm/action-setup@v6
+
+      - name: 🏗 Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🔍 Typecheck
+        run: pnpm run typecheck
+
+      - name: 🏗 Build
+        run: pnpm run build


### PR DESCRIPTION
Vercel was the only check on a PR, and it skips types because `ignoreBuildErrors` is on. So a type error reached main and sat there, see #122.

`verify` installs with a frozen lockfile, runs `pnpm typecheck`, then `pnpm build`. Same node and pnpm setup as `generate-files.yml`. Concurrency group cancels a superseded run on the same ref.

`lint` is out until #121 is fixed.