### PR TITLE
fix(ci): unbreak the static file generation push

### DIFF
--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -41,9 +41,11 @@ jobs:
           git config --global user.name "Gabriel Taveira"
           git config --global user.email "action@github.com"
           git add .
-          git commit -m 'chore: update website pdf 💾 [skip ci]'
+          # Nothing to do when the render is byte-identical to what's committed.
+          git diff --cached --quiet && echo "pdf unchanged" && exit 0
 
-          git pull
+          git commit -m 'chore: update website pdf 💾 [skip ci]'
+          git pull --rebase --autostash
           git push
 
   generate-gif:
@@ -63,7 +65,9 @@ jobs:
           git config --global user.name "Gabriel Taveira"
           git config --global user.email "action@github.com"
           git add .
-          git commit -m 'chore: update website gif 💾 [skip ci]'
+          # Nothing to do when the capture is byte-identical to what's committed.
+          git diff --cached --quiet && echo "gif unchanged" && exit 0
 
-          git pull
+          git commit -m 'chore: update website gif 💾 [skip ci]'
+          git pull --rebase --autostash
           git push


### PR DESCRIPTION
`generate-files.yml` has failed every run since May, always in `generate-gif`, always here:

```
fatal: Need to specify how to reconcile divergent branches.
```

`generate-gif` runs after `generate-pdf`, so by the time it pushes, main has moved. The runner has no `pull.rebase` set, so a non-fast-forward `git pull` aborts. In the run from today, origin/main went `7fe0694..46ca063` mid-pull. `--rebase --autostash` covers it.

`generate-pdf` keeps passing because it pushes first, which is why the PDF is current (`db61c0d`, today) while the GIF has not been updated since `ca3e300` in October 2024.

Both steps also called `git commit` unconditionally, which exits non-zero when the render comes out byte-identical to what is already committed. They now check the index and stop early.