### PR TITLE
feat!: move to typescript 7

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,12 @@ const nextConfig = {
   reactCompiler: true,
   experimental: {
     optimizeCss: true,
+    /**
+     * TypeScript 7 ships the native compiler and no `lib/typescript.js`, so
+     * Next has to spawn the `tsc` binary instead of importing the compiler API.
+     * Without this the build fails with E1150 before it compiles anything.
+     */
+    useTypeScriptCli: true,
   },
   /** Typecheck via `tsc`, not as part of the build */
   typescript: { ignoreBuildErrors: true },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "19.2.8",
     "react-wrap-balancer": "^1.1.1",
     "tailwindcss": "4.3.3",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ dependencies:
     version: 16.2.12(@babel/core@7.29.7)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8)(react@19.2.8)
   next-intl:
     specifier: 4.13.4
-    version: 4.13.4(next@16.2.12)(react@19.2.8)(typescript@6.0.3)
+    version: 4.13.4(next@16.2.12)(react@19.2.8)(typescript@7.0.2)
   postcss:
     specifier: ^8.5.18
     version: 8.5.23
@@ -50,8 +50,8 @@ dependencies:
     specifier: 4.3.3
     version: 4.3.3
   typescript:
-    specifier: 6.0.3
-    version: 6.0.3
+    specifier: 7.0.2
+    version: 7.0.2
 
 devDependencies:
   '@eslint/compat':
@@ -89,7 +89,7 @@ devDependencies:
     version: 2.7.0
   magic-eslint-config:
     specifier: ^0.1.9
-    version: 0.1.9(@babel/eslint-parser@7.29.7)(jest@30.4.2)(jiti@2.7.0)(prettier@3.9.6)(tailwindcss@4.3.3)(typescript@6.0.3)
+    version: 0.1.9(@babel/eslint-parser@7.29.7)(jest@30.4.2)(jiti@2.7.0)(prettier@3.9.6)(tailwindcss@4.3.3)(typescript@7.0.2)
   puppeteer:
     specifier: ^25.0.0
     version: 25.3.0
@@ -1650,7 +1650,7 @@ packages:
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
     dev: false
 
-  /@shopify/eslint-plugin@48.0.2(@typescript-eslint/eslint-plugin@8.34.0)(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(jest@30.4.2)(prettier@3.9.6)(typescript@6.0.3):
+  /@shopify/eslint-plugin@48.0.2(@typescript-eslint/eslint-plugin@8.34.0)(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(jest@30.4.2)(prettier@3.9.6)(typescript@7.0.2):
     resolution: {integrity: sha512-kf8bOpSDpa/S6manD6EtQiMD1+kS8MG/ZT+sOgbO0hriPiMd37p6BwC8aY3enW5qTxWuVmVNY/tzIhrXV0naIg==}
     peerDependencies:
       eslint: ^8.56.0
@@ -1663,10 +1663,10 @@ packages:
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.0)(eslint-import-resolver-node@0.3.9)(eslint@9.39.5)
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.39.5)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)
-      eslint-plugin-jest: 28.13.3(@typescript-eslint/eslint-plugin@8.34.0)(eslint@9.39.5)(jest@30.4.2)(typescript@6.0.3)
+      eslint-plugin-jest: 28.13.3(@typescript-eslint/eslint-plugin@8.34.0)(eslint@9.39.5)(jest@30.4.2)(typescript@7.0.2)
       eslint-plugin-jest-formatting: 3.1.0(eslint@9.39.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
-      eslint-plugin-n: 17.19.0(eslint@9.39.5)(typescript@6.0.3)
+      eslint-plugin-n: 17.19.0(eslint@9.39.5)(typescript@7.0.2)
       eslint-plugin-prettier: 5.4.1(eslint-config-prettier@9.1.0)(eslint@9.39.5)(prettier@3.9.6)
       eslint-plugin-promise: 7.2.1(eslint@9.39.5)
       eslint-plugin-react: 7.37.5(eslint@9.39.5)
@@ -1676,7 +1676,7 @@ packages:
       jsx-ast-utils: 3.3.5
       pkg-dir: 5.0.0
       pluralize: 8.0.0
-      typescript-eslint: 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      typescript-eslint: 8.34.0(eslint@9.39.5)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@types/eslint'
       - '@typescript-eslint/eslint-plugin'
@@ -2117,7 +2117,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/eslint-plugin@8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2126,35 +2126,35 @@ packages:
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@7.0.2)
       '@typescript-eslint/scope-manager': 8.34.0
-      '@typescript-eslint/type-utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 8.34.0
       eslint: 9.39.5(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@5.33.0(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/experimental-utils@5.33.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-NvRsNe+T90QrSVlgdV9/U8/chfqGmShvKUE7hWZTAUUCF6hZty/R+eMPVGldKcUDq7uRQaK6+V8gv5OwVDqC+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.33.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 5.33.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@8.34.0(eslint@10.8.0)(typescript@6.0.3):
+  /@typescript-eslint/parser@8.34.0(eslint@10.8.0)(typescript@7.0.2):
     resolution: {integrity: sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2163,16 +2163,16 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
-      '@typescript-eslint/typescript-estree': 8.34.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 8.34.0
       debug: 4.4.3
       eslint: 10.8.0(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.34.0(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/parser@8.34.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2181,25 +2181,25 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
-      '@typescript-eslint/typescript-estree': 8.34.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 8.34.0
       debug: 4.4.3
       eslint: 9.39.5(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/project-service@8.34.0(typescript@6.0.3):
+  /@typescript-eslint/project-service@8.34.0(typescript@7.0.2):
     resolution: {integrity: sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.34.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2228,28 +2228,28 @@ packages:
       '@typescript-eslint/visitor-keys': 8.34.0
     dev: true
 
-  /@typescript-eslint/tsconfig-utils@8.34.0(typescript@6.0.3):
+  /@typescript-eslint/tsconfig-utils@8.34.0(typescript@7.0.2):
     resolution: {integrity: sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     dev: true
 
-  /@typescript-eslint/type-utils@8.34.0(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/type-utils@8.34.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.34.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       debug: 4.4.3
       eslint: 9.39.5(jiti@2.7.0)
-      ts-api-utils: 2.1.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2269,7 +2269,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.33.0(typescript@6.0.3):
+  /@typescript-eslint/typescript-estree@5.33.0(typescript@7.0.2):
     resolution: {integrity: sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2284,13 +2284,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
-      tsutils: 3.21.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tsutils: 3.21.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.19.1(typescript@6.0.3):
+  /@typescript-eslint/typescript-estree@8.19.1(typescript@7.0.2):
     resolution: {integrity: sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2303,20 +2303,20 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.5
-      ts-api-utils: 2.1.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.34.0(typescript@6.0.3):
+  /@typescript-eslint/typescript-estree@8.34.0(typescript@7.0.2):
     resolution: {integrity: sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@typescript-eslint/project-service': 8.34.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.34.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.34.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/visitor-keys': 8.34.0
       debug: 4.4.3
@@ -2324,13 +2324,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.5
-      ts-api-utils: 2.1.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.1.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.33.0(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/utils@5.33.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2339,7 +2339,7 @@ packages:
       '@types/json-schema': 7.0.15
       '@typescript-eslint/scope-manager': 5.33.0
       '@typescript-eslint/types': 5.33.0
-      '@typescript-eslint/typescript-estree': 5.33.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 5.33.0(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@9.39.5)
@@ -2348,7 +2348,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@8.19.1(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/utils@8.19.1(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2358,14 +2358,14 @@ packages:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.19.1
       '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/typescript-estree': 8.19.1(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.19.1(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@8.34.0(eslint@9.39.5)(typescript@6.0.3):
+  /@typescript-eslint/utils@8.34.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -2375,9 +2375,9 @@ packages:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
-      '@typescript-eslint/typescript-estree': 8.34.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.34.0(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2405,6 +2405,166 @@ packages:
       '@typescript-eslint/types': 8.34.0
       eslint-visitor-keys: 4.2.1
     dev: true
+
+  /@typescript/typescript-aix-ppc64@7.0.2:
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-darwin-arm64@7.0.2:
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-darwin-x64@7.0.2:
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-freebsd-arm64@7.0.2:
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-freebsd-x64@7.0.2:
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-arm64@7.0.2:
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-arm@7.0.2:
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-loong64@7.0.2:
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-mips64el@7.0.2:
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-ppc64@7.0.2:
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-riscv64@7.0.2:
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-s390x@7.0.2:
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-linux-x64@7.0.2:
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-netbsd-arm64@7.0.2:
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-netbsd-x64@7.0.2:
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-openbsd-arm64@7.0.2:
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-openbsd-x64@7.0.2:
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-sunos-x64@7.0.2:
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-win32-arm64@7.0.2:
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@typescript/typescript-win32-x64@7.0.2:
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
 
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3561,7 +3721,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@7.0.2)
       debug: 3.2.7
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
@@ -3616,7 +3776,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@7.0.2)
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -3651,7 +3811,7 @@ packages:
       eslint: 9.39.5(jiti@2.7.0)
     dev: true
 
-  /eslint-plugin-jest@28.13.3(@typescript-eslint/eslint-plugin@8.34.0)(eslint@9.39.5)(jest@30.4.2)(typescript@6.0.3):
+  /eslint-plugin-jest@28.13.3(@typescript-eslint/eslint-plugin@8.34.0)(eslint@9.39.5)(jest@30.4.2)(typescript@7.0.2):
     resolution: {integrity: sha512-BwC7TkFKn59tyfi6Zd9p/bcVVYOjWqp80jeaQvMy1fNFo8iDF8D5XvoSMM7CPaL6lQXPXCgD+RD4onlSsFelIw==}
     engines: {node: ^16.10.0 || ^18.12.0 || >=20.0.0}
     peerDependencies:
@@ -3664,8 +3824,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
       jest: 30.4.2(@types/node@26.1.1)
     transitivePeerDependencies:
@@ -3697,14 +3857,14 @@ packages:
       string.prototype.includes: 2.0.1
     dev: true
 
-  /eslint-plugin-n@17.19.0(eslint@9.39.5)(typescript@6.0.3):
+  /eslint-plugin-n@17.19.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-qxn1NaDHtizbhVAPpbMT8wWFaLtPnwhfN/e+chdu2i6Vgzmo/tGM62tcJ1Hf7J5Ie4dhse3DOPMmDxduzfifzw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       enhanced-resolve: 5.24.3
       eslint: 9.39.5(jiti@2.7.0)
       eslint-plugin-es-x: 7.8.0(eslint@9.39.5)
@@ -3713,20 +3873,20 @@ packages:
       ignore: 5.3.2
       minimatch: 9.0.9
       semver: 7.8.5
-      ts-declaration-location: 1.0.7(typescript@6.0.3)
+      ts-declaration-location: 1.0.7(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-prefer-arrow-functions@3.6.2(eslint@9.39.5)(typescript@6.0.3):
+  /eslint-plugin-prefer-arrow-functions@3.6.2(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-rSgMW1GFRXacz4FoLV+y56QoDj+pQOtpikaFL2OzEpoDK4umMMG4ONd9W59NLqSjstRqHjefrxco5KRkqxAe9g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       eslint: '>=9.17.0'
     dependencies:
       '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/utils': 8.19.1(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.19.1(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -3842,16 +4002,16 @@ packages:
       string.prototype.repeat: 1.0.0
     dev: true
 
-  /eslint-plugin-reanimated@2.0.1(@babel/eslint-parser@7.29.7)(eslint@9.39.5)(typescript@6.0.3):
+  /eslint-plugin-reanimated@2.0.1(@babel/eslint-parser@7.29.7)(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-lxoQdNRuMBeA5s83GzcjGzKEQTKkByfXaUAVNxYY8z/te3x3IdfOQrQKruNC68IcvSc1rL08+op0RjcSM25wHg==}
     peerDependencies:
       eslint: '>=8'
       typescript: '>=4.1.3'
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.33.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/experimental-utils': 5.33.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.29.7)(eslint@9.39.5)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@babel/eslint-parser'
       - supports-color
@@ -3877,14 +4037,14 @@ packages:
       tailwindcss: 4.3.3
     dev: true
 
-  /eslint-plugin-testing-library@7.5.2(eslint@9.39.5)(typescript@6.0.3):
+  /eslint-plugin-testing-library@7.5.2(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-8WJOBsV+RZRNJE1dbtJie5oPpU2c6SvUUQ8/tyDQwXUPW1UCpVvlef3lvoPVQfOlGfO/6r2yOuCXFxii0zrpqQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: ^9.14.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.0
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -3900,7 +4060,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
     dev: true
 
@@ -5529,31 +5689,31 @@ packages:
     dependencies:
       yallist: 3.1.1
 
-  /magic-eslint-config@0.1.9(@babel/eslint-parser@7.29.7)(jest@30.4.2)(jiti@2.7.0)(prettier@3.9.6)(tailwindcss@4.3.3)(typescript@6.0.3):
+  /magic-eslint-config@0.1.9(@babel/eslint-parser@7.29.7)(jest@30.4.2)(jiti@2.7.0)(prettier@3.9.6)(tailwindcss@4.3.3)(typescript@7.0.2):
     resolution: {integrity: sha512-qbqmEZFqzVbo0vwSCP8nNTqVS7tdd5I70RPf0Cfn+86Q4ju/zUGEEPGptc6xAl7UCl21XSgnmFVC+tMz2FHlQA==}
     dependencies:
       '@eslint/compat': 1.3.0(eslint@9.39.5)
       '@next/eslint-plugin-next': 15.3.3
-      '@shopify/eslint-plugin': 48.0.2(@typescript-eslint/eslint-plugin@8.34.0)(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(jest@30.4.2)(prettier@3.9.6)(typescript@6.0.3)
-      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@6.0.3)
+      '@shopify/eslint-plugin': 48.0.2(@typescript-eslint/eslint-plugin@8.34.0)(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(jest@30.4.2)(prettier@3.9.6)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/parser': 8.34.0(eslint@10.8.0)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.39.5)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)
       eslint-plugin-jest-formatting: 3.1.0(eslint@9.39.5)
-      eslint-plugin-prefer-arrow-functions: 3.6.2(eslint@9.39.5)(typescript@6.0.3)
+      eslint-plugin-prefer-arrow-functions: 3.6.2(eslint@9.39.5)(typescript@7.0.2)
       eslint-plugin-prettier: 5.4.1(eslint-config-prettier@9.1.0)(eslint@9.39.5)(prettier@3.9.6)
       eslint-plugin-react: 7.37.5(eslint@9.39.5)
       eslint-plugin-react-compiler: 19.0.0-beta-e993439-20250405(eslint@9.39.5)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.5)
       eslint-plugin-react-native: 5.0.0(eslint@9.39.5)
       eslint-plugin-react-native-a11y: 3.5.1(eslint@9.39.5)
-      eslint-plugin-reanimated: 2.0.1(@babel/eslint-parser@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+      eslint-plugin-reanimated: 2.0.1(@babel/eslint-parser@7.29.7)(eslint@9.39.5)(typescript@7.0.2)
       eslint-plugin-tailwindcss: 3.18.0(tailwindcss@4.3.3)
-      eslint-plugin-testing-library: 7.5.2(eslint@9.39.5)(typescript@6.0.3)
+      eslint-plugin-testing-library: 7.5.2(eslint@9.39.5)(typescript@7.0.2)
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.34.0)(eslint@9.39.5)
       globals: 16.2.0
-      typescript-eslint: 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      typescript-eslint: 8.34.0(eslint@9.39.5)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@babel/eslint-parser'
       - '@types/eslint'
@@ -5680,7 +5840,7 @@ packages:
     resolution: {integrity: sha512-uN1+NMUYbG6YkO3q+rjc2bvAPX9nQ23owemvHJAyW0pRbQjVDwvNhmrV5qaak0oQc/9okbK17KLT49AoMGhVEQ==}
     dev: false
 
-  /next-intl@4.13.4(next@16.2.12)(react@19.2.8)(typescript@6.0.3):
+  /next-intl@4.13.4(next@16.2.12)(react@19.2.8)(typescript@7.0.2):
     resolution: {integrity: sha512-jhPAT0u0lahIK6E4gVdZAehugWCosBhLG8sV7xMzgSVoJpxHObP+Fiu+z2FfkEW0XPPtr7uEXoUlLEfhxhNMTg==}
     peerDependencies:
       next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -5699,7 +5859,7 @@ packages:
       next-intl-swc-plugin-extractor: 4.13.4
       po-parser: 2.1.1
       react: 19.2.8
-      typescript: 6.0.3
+      typescript: 7.0.2
       use-intl: 4.13.4(react@19.2.8)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -6708,22 +6868,22 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-api-utils@2.1.0(typescript@6.0.3):
+  /ts-api-utils@2.1.0(typescript@7.0.2):
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     dev: true
 
-  /ts-declaration-location@1.0.7(typescript@6.0.3):
+  /ts-declaration-location@1.0.7(typescript@7.0.2):
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
       typescript: '>=4.0.0'
     dependencies:
       picomatch: 4.0.4
-      typescript: 6.0.3
+      typescript: 7.0.2
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -6742,14 +6902,14 @@ packages:
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  /tsutils@3.21.0(typescript@6.0.3):
+  /tsutils@3.21.0(typescript@7.0.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 6.0.3
+      typescript: 7.0.2
     dev: true
 
   /type-check@0.4.0:
@@ -6818,26 +6978,47 @@ packages:
     resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
     dev: true
 
-  /typescript-eslint@8.34.0(eslint@9.39.5)(typescript@6.0.3):
+  /typescript-eslint@8.34.0(eslint@9.39.5)(typescript@7.0.2):
     resolution: {integrity: sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.34.0(@typescript-eslint/parser@8.34.0)(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/parser': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5(jiti@2.7.0)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  /typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}

--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,6 @@
       "matchDepTypes": ["pnpm.overrides"],
       "matchUpdateTypes": ["major"],
       "enabled": false
-    },
-    {
-      "description": "typescript-eslint reads the JS compiler API for every type-aware rule, and its latest release (8.65.0) still peers on typescript <6.1.0. TypeScript 7 ships only the native compiler and drops that API. Lift this once the peer range allows 7.",
-      "matchPackageNames": ["typescript"],
-      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
Reversing #120. I'm fine with TypeScript 7 and taking the loss on type-aware lint, so this lands the version renovate proposed in #119.

TypeScript 7 is the native Go compiler and its npm package ships no `lib/typescript.js`, so Next cannot import the compiler API. `experimental.useTypeScriptCli` makes it spawn the `tsc` binary. Without the flag:

```
Error: TypeScript 7.0.2 does not provide the compiler API required by Next.js.
Enable experimental.useTypeScriptCli in your Next.js config to use the
TypeScript CLI, or install TypeScript 6 instead.
```

Both CI steps pass on 7 unchanged. `pnpm typecheck` still shells to `tsc --noEmit`, now the native binary, and `tsc` accepts the `target: ES2017` that #122 set. The lockfile carries all 20 platform packages including `@typescript/typescript-linux-x64`, so `--frozen-lockfile` on ubuntu-latest resolves the Linux binary.

Deleted the renovate `allowedVersions: "<7"` entry from #120.

Proof, local `pnpm typecheck` and `pnpm build` on 7 plus the built site served by `pnpm start`:

![typescript 7 build and site](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/ts7-adoption/typescript-7-build-and-site.png)

`ls node_modules/typescript/lib` in that output shows `getExePath.js`, `tsc.js`, `version.cjs`, and no `typescript.js`. typescript-eslint needs that file.

The hero contact button that #122 fixed still lands on target under the new compiler, `scrollY` 6318 against a target of 6318.

### Costs

`pnpm lint` cannot run type-aware rules on 7. Forcing typescript-eslint on with overrides crashes:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree/dist/create-program/shared.js:59
```

Lint stays out of CI. #121 covers it and now records the TS 7 constraint. `typecheck` and `build` on every PR are the only guard left on this repo.