### PR TITLE
ci: land the generated PDF and GIF through a pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  # `Generate static files` dispatches this on its asset branch, because a PR
+  # opened with GITHUB_TOKEN does not start `pull_request` workflows.
+  workflow_dispatch:
 
 # A new push to the same branch makes the previous run irrelevant.
 concurrency:

--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -10,8 +10,19 @@ on:
       - "public/**"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  # Needed to start ci.yml on the asset branch, see the step that does it.
+  actions: write
+
+# Two overlapping runs would fight over the same asset branch.
+concurrency:
+  group: generate-files
+  cancel-in-progress: false
+
 jobs:
-  generate-pdf:
+  generate:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup Repo
@@ -28,7 +39,7 @@ jobs:
           node-version: 24.x
 
       - name: 📦 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: 🏗 Install ghostscript
         run: sudo apt-get update && sudo apt-get install -y ghostscript
@@ -36,38 +47,44 @@ jobs:
       - name: 🖨️ Generate PDF
         run: pnpm run get:pdf
 
-      - name: 📤 Commit PDF
-        run: |
-          git config --global user.name "Gabriel Taveira"
-          git config --global user.email "action@github.com"
-          git add .
-          # Nothing to do when the render is byte-identical to what's committed.
-          git diff --cached --quiet && echo "pdf unchanged" && exit 0
-
-          git commit -m 'chore: update website pdf 💾 [skip ci]'
-          git pull --rebase --autostash
-          git push
-
-  generate-gif:
-    needs: generate-pdf
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🏗 Setup Repo
-        uses: actions/checkout@v7
-
-      - name: 🤖 Website to file
+      - name: 🤖 Capture the site GIF
         uses: PabloLec/website-to-gif@2.1.5
         with:
           url: "https://www.gabrieltaveira.dev"
 
-      - name: 📤 Commit GIF
-        run: |
-          git config --global user.name "Gabriel Taveira"
-          git config --global user.email "action@github.com"
-          git add .
-          # Nothing to do when the capture is byte-identical to what's committed.
-          git diff --cached --quiet && echo "gif unchanged" && exit 0
+      # main requires the `verify` check, so these assets land through a PR
+      # instead of a direct push. add-paths keeps everything else the render
+      # touches out of the commit.
+      - name: 📤 Open the asset PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          branch: chore/regenerate-static-files
+          add-paths: |
+            demo.gif
+            public/curriculum.pdf
+          commit-message: "chore: update the website pdf and gif 💾"
+          title: "chore: update the website pdf and gif 💾"
+          body: |
+            Regenerated `public/curriculum.pdf` from the live site and
+            recaptured `demo.gif`. Opened by the `Generate static files`
+            workflow and set to auto-merge once `verify` passes.
+          author: Gabriel Taveira <action@github.com>
+          committer: Gabriel Taveira <action@github.com>
+          delete-branch: true
 
-          git commit -m 'chore: update website gif 💾 [skip ci]'
-          git pull --rebase --autostash
-          git push
+      # A PR opened with GITHUB_TOKEN does not start `pull_request` workflows,
+      # so `verify` would never report and auto-merge would wait forever.
+      # workflow_dispatch is the documented exception to that rule.
+      - name: 🔍 Start CI on the asset branch
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ci.yml --ref chore/regenerate-static-files
+
+      - name: 🚀 Queue auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --auto --squash


### PR DESCRIPTION
Groundwork for requiring `verify` on main. The workflow pushes the regenerated PDF and GIF straight to main as `github-actions[bot]`, and a required check rejects that push.

The bot can't be handed a ruleset bypass here. GitHub only accepts `RepositoryRole` admin as a bypass actor on a user-owned repo, and the bot doesn't hold that role:

```
Actor GitHub Actions integration must be part of the ruleset source or owner organization
```

So the assets go through a PR now, with auto-merge queued so they still land without me touching anything. `add-paths` pins the commit to `demo.gif` and `public/curriculum.pdf`.

The two jobs become one. `generate-gif` only had `needs: generate-pdf` so their pushes wouldn't race each other, and a single PR carrying both assets removes that.

A PR opened with `GITHUB_TOKEN` doesn't start `pull_request` workflows, so `verify` would sit at "expected" and auto-merge would never fire. `workflow_dispatch` is exempt from that rule, so the workflow dispatches `ci.yml` on the asset branch and `ci.yml` picks up a `workflow_dispatch` trigger.

Also flipped on repo-level auto-merge, which was off.

The ruleset change comes after this, once I've seen the GIF reach main through the new path.