### PR TITLE
fix(ci): approve the asset PR's parked CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - main
-  # `Generate static files` dispatches this on its asset branch, because a PR
-  # opened with GITHUB_TOKEN does not start `pull_request` workflows.
+  # For re-running verify by hand without pushing anything.
   workflow_dispatch:
 
 # A new push to the same branch makes the previous run irrelevant.

--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -74,14 +74,28 @@ jobs:
           committer: Gabriel Taveira <action@github.com>
           delete-branch: true
 
-      # A PR opened with GITHUB_TOKEN does not start `pull_request` workflows,
-      # so `verify` would never report and auto-merge would wait forever.
-      # workflow_dispatch is the documented exception to that rule.
-      - name: 🔍 Start CI on the asset branch
+      # A PR opened with GITHUB_TOKEN parks its `pull_request` run at
+      # action_required, so `verify` never reports and auto-merge waits
+      # forever. Approving the parked run is what releases it. Dispatching
+      # ci.yml on the branch does not work here: the check it produces isn't
+      # attached to the PR, so the required check stays unsatisfied.
+      - name: 🔍 Release the PR's CI run
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run ci.yml --ref chore/regenerate-static-files
+          SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          for _ in $(seq 1 20); do
+            id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$SHA" \
+              --jq '[.workflow_runs[] | select(.conclusion == "action_required")][0].id')
+            if [ -n "$id" ] && [ "$id" != "null" ]; then
+              gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/approve"
+              echo "approved run $id"
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "::warning::no parked pull_request run for $SHA, check whether $SHA got a verify run"
 
       - name: 🚀 Queue auto-merge
         if: steps.cpr.outputs.pull-request-number


### PR DESCRIPTION
The `workflow_dispatch` trick from #132 doesn't satisfy main's required `verify` context. Caught it on #136, which sat at `BLOCKED` for ten minutes with auto-merge enabled and a green `verify` run.

`GET /commits/{sha}/check-runs` showed `verify: success` from app 15368, while the PR's `statusCheckRollup` listed only the two Vercel contexts. The ruleset reads that rollup, and a `workflow_dispatch` check suite has no PR attached, so its check never reaches it.

A PR opened with `GITHUB_TOKEN` gets a `pull_request` run parked at `conclusion: action_required`.

```
{"event":"pull_request","status":"completed","conclusion":"action_required",
 "actor":"github-actions[bot]","head_branch":"chore/regenerate-static-files"}
```

`POST /actions/runs/{id}/approve` releases it. I ran that by hand on #136 and the run went `action_required` -> `in_progress` -> `success`, then auto-merge fired and the assets landed on main.

`generate-files.yml` now polls the new PR's head SHA for that parked run, twenty attempts six seconds apart, and approves the first one it finds. If no parked run turns up, the step logs a warning.

I don't know yet whether `GITHUB_TOKEN` can approve a run it triggered, since I approved #136 myself. The next asset run will show it.