### PR TITLE
fix(ci): approve the release PR's parked CI run too

### DIFF
--- a/.github/actions/approve-parked-ci/action.yml
+++ b/.github/actions/approve-parked-ci/action.yml
@@ -1,0 +1,41 @@
+name: Approve parked CI
+description: >
+  Releases the pull_request workflow run that GitHub parks at
+  conclusion action_required when a PR is opened with GITHUB_TOKEN. main
+  requires the `verify` context, and the ruleset only reads checks attached to
+  the PR, so a parked run leaves the PR unmergeable forever.
+
+inputs:
+  pull-request:
+    description: Number of the pull request whose run should be released.
+    required: true
+  token:
+    description: Token with actions:write on this repository.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR: ${{ inputs.pull-request }}
+      run: |
+        set -euo pipefail
+
+        sha=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+        echo "pull request #$PR is at $sha"
+
+        # The run shows up a little after the PR does, so poll for it.
+        for _ in $(seq 1 20); do
+          id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$sha" \
+            --jq '[.workflow_runs[] | select(.conclusion == "action_required")][0].id')
+          if [ -n "$id" ] && [ "$id" != "null" ]; then
+            gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/approve"
+            echo "approved run $id"
+            exit 0
+          fi
+          sleep 6
+        done
+
+        echo "::warning::no parked pull_request run for $sha, check whether it got a verify run"

--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -74,28 +74,12 @@ jobs:
           committer: Gabriel Taveira <action@github.com>
           delete-branch: true
 
-      # A PR opened with GITHUB_TOKEN parks its `pull_request` run at
-      # action_required, so `verify` never reports and auto-merge waits
-      # forever. Approving the parked run is what releases it. Dispatching
-      # ci.yml on the branch does not work here: the check it produces isn't
-      # attached to the PR, so the required check stays unsatisfied.
       - name: 🔍 Release the PR's CI run
         if: steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
-        run: |
-          for _ in $(seq 1 20); do
-            id=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$SHA" \
-              --jq '[.workflow_runs[] | select(.conclusion == "action_required")][0].id')
-            if [ -n "$id" ] && [ "$id" != "null" ]; then
-              gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$id/approve"
-              echo "approved run $id"
-              exit 0
-            fi
-            sleep 6
-          done
-          echo "::warning::no parked pull_request run for $SHA, check whether $SHA got a verify run"
+        uses: ./.github/actions/approve-parked-ci
+        with:
+          pull-request: ${{ steps.cpr.outputs.pull-request-number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🚀 Queue auto-merge
         if: steps.cpr.outputs.pull-request-number

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,32 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to release the release PR's parked CI run, see the step that does it.
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v7
+
       # Keeps a release PR open with the pending CHANGELOG.md and version bump,
       # derived from conventional commits since the last tag. Merging it cuts
       # the tag and the GitHub release. `!` or a BREAKING CHANGE: footer bumps
       # the major and lands under a breaking-changes heading in both.
       - name: 🚀 Release Please
+        id: release
         uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The release PR is opened with GITHUB_TOKEN too, so it needs the same
+      # nudge as the asset PR or it can never satisfy `verify`.
+      - name: 🔍 Release the release PR's CI run
+        if: steps.release.outputs.prs_created == 'true'
+        uses: ./.github/actions/approve-parked-ci
+        with:
+          pull-request: ${{ fromJson(steps.release.outputs.pr).number }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release PR hits the same wall the asset PR did. #133 is at `BLOCKED` with its CI run parked:

```
30230014182  CI  completed/action_required
```

Its rollup carries `Vercel Preview Comments` and nothing named `verify`, so main's required context can never be satisfied and the release can't be cut without an admin bypass.

release-please opens that PR with `GITHUB_TOKEN`, same as `peter-evans/create-pull-request` does for the assets. The approve loop from #137 moves into `.github/actions/approve-parked-ci` and both workflows call it. It takes a PR number, resolves the head SHA itself, and approves the parked run.

`release.yml` gains `actions: write` for the approve call. It also gains a checkout step, because a local composite action has to be on disk before a workflow can reference it.

#137 left open whether `GITHUB_TOKEN` can approve a run it triggered. The asset run logged `approved run 30230167273` and #138 merged on its own.

I'll approve #133's run by hand once this lands, since its PR predates the change.