### PR TITLE
ci: probe the R2 credentials instead of only checking they exist

### DIFF
--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -52,6 +52,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Fail here rather than four minutes later inside a wrangler stack trace.
+      #
+      # "Missing" would be the wrong word. A secret saved with an empty value
+      # lists in the API exactly like a real one and arrives on the runner as an
+      # empty string, which is how the first live run failed while
+      # `gh secret list` showed both names present.
       - name: 🔑 Check Cloudflare credentials
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -59,16 +64,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          missing=""
-          [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || missing="$missing CLOUDFLARE_API_TOKEN"
-          [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || missing="$missing CLOUDFLARE_ACCOUNT_ID"
+          empty=""
+          [ -n "${CLOUDFLARE_API_TOKEN:-}" ] || empty="$empty CLOUDFLARE_API_TOKEN"
+          [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] || empty="$empty CLOUDFLARE_ACCOUNT_ID"
 
-          if [ -n "$missing" ]; then
-            echo "::error::Missing repository secret(s):$missing. The token needs Account > R2 > Edit on the account that owns the $R2_BUCKET bucket."
+          if [ -n "$empty" ]; then
+            echo "::error::Repository secret(s) unset or set to an empty value:$empty. Listing the name proves nothing, re-save the value. The token needs Account > R2 > Edit on the account that owns $R2_BUCKET."
             exit 1
           fi
 
-          echo "both secrets are present"
+          # Cheapest call that proves all three things at once: the token
+          # authenticates, the account id belongs to it, and it carries R2
+          # permissions. Takes about seven seconds.
+          if ! pnpm exec wrangler r2 bucket info "$R2_BUCKET"; then
+            echo "::error::Both secrets have values but they cannot read $R2_BUCKET. Check the token has Account > R2 > Edit and that CLOUDFLARE_ACCOUNT_ID owns the bucket."
+            exit 1
+          fi
+
+          echo "credentials reach $R2_BUCKET"
 
       - name: 🏗 Install ghostscript
         run: sudo apt-get update && sudo apt-get install -y ghostscript


### PR DESCRIPTION
The first live run of #143 failed on `CLOUDFLARE_API_TOKEN` while `gh secret list` showed it present. The value had been saved empty, which lists exactly like a real secret and reaches the runner as an empty string. Straight from that run's log:

```
CLOUDFLARE_API_TOKEN: 
CLOUDFLARE_ACCOUNT_ID: ***
```

So "Missing" was the wrong word and it sent me looking at the name instead of the value. The check says unset or empty now, and tells you to re-save the value.

After that it runs `wrangler r2 bucket info`, seven seconds, which proves the token authenticates, the account id belongs to it, and it carries R2 permissions. A wrong or under-scoped token also dies in the first ten seconds, before the four minutes of puppeteer and ghostscript.

Both failure paths run, full messages:

```
empty token:
::error::Repository secret(s) unset or set to an empty value: CLOUDFLARE_API_TOKEN. Listing the
name proves nothing, re-save the value. The token needs Account > R2 > Edit on the account that
owns portfolio-assets.
exit 1

bogus token, real account id:
::error::Both secrets have values but they cannot read portfolio-assets. Check the token has
Account > R2 > Edit and that CLOUDFLARE_ACCOUNT_ID owns the bucket.
exit 1
```

and the probe on its own with credentials that work:

```
$ wrangler r2 bucket info portfolio-assets
name: portfolio-assets   location: ENAM   default_storage_class: Standard
7.2s, exit 0
```

`CLOUDFLARE_API_TOKEN` still needs its value re-saved before the workflow can get past this step.
