### PR TITLE
build(deps): replace deprecated critters with beasties

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,15 @@ const nextConfig = {
       },
     ]),
   experimental: {
+    /**
+     * Next inlines critical CSS with a literal `require("critters")` in
+     * `postProcessHTML`, so that specifier has to keep resolving. critters is
+     * deprecated, so package.json aliases the name to `beasties`, the fork the
+     * Nuxt team took over. Both builds produce byte-identical inlined CSS.
+     *
+     * When Next starts requiring `beasties` by name, drop the alias and depend
+     * on it directly.
+     */
     optimizeCss: true,
     /**
      * TypeScript 7 ships the native compiler and no `lib/typescript.js`, so

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "babel-plugin-react-compiler": "1.0.0",
-    "critters": "^0.0.25",
+    "critters": "npm:beasties@^0.4.3",
     "magic-codemods": "^1.1.0",
     "magic-oxfmt-config": "^1.2.0",
     "magic-oxlint-config": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       critters:
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: npm:beasties@^0.4.3
+        version: beasties@0.4.3
       magic-codemods:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1399,6 +1399,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  beasties@0.4.3:
+    resolution: {integrity: sha512-fIIeLOcbAB/K1kb1HBVJoiq1alHL4RCYBSo5e7HzrNkkgMggXR1Vqt/Z9JWnkfe/qdCo66Ux3QRwZioAIBdWRA==}
+    engines: {node: '>=18.0.0'}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -1453,19 +1457,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  critters@0.0.25:
-    resolution: {integrity: sha512-ROF/tjJyyRdM8/6W0VqoN5Ql05xAGnkf5b7f3sTEl1bI5jTQQf8O918RD/V9tEb9pRY/TKcvJekDbJtniHyPtQ==}
-    deprecated: Ownership of Critters has moved to the Nuxt team, who will be maintaining the project going forward. If you'd like to keep using Critters, please switch to the actively-maintained fork at https://github.com/danielroe/beasties
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
 
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
 
   csstype@3.2.3:
@@ -1512,6 +1512,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   error-stack-parser-es@1.0.5:
@@ -1647,8 +1651,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  htmlparser2@8.0.2:
-    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   icu-minify@4.13.4:
     resolution: {integrity: sha512-yK6HyPLGlQjqm8fTKtnBpM77z7vl7JdDBN2EXLvmgAu/b7XaOHWZb73M3ISl9ahBTehBv7RYeqqWSHfk1v2YcA==}
@@ -1967,6 +1971,12 @@ packages:
 
   postcss-media-query-parser@0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.5.18
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3002,6 +3012,18 @@ snapshots:
 
   baseline-browser-mapping@2.11.3: {}
 
+  beasties@0.4.3:
+    dependencies:
+      css-select: 6.0.0
+      css-what: 7.0.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      htmlparser2: 10.1.0
+      picocolors: 1.1.1
+      postcss: 8.5.23
+      postcss-media-query-parser: 0.2.3
+      postcss-safe-parser: 7.0.1(postcss@8.5.23)
+
   blake3-wasm@2.1.5: {}
 
   boolbase@1.0.0: {}
@@ -3050,31 +3072,21 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  critters@0.0.25:
-    dependencies:
-      chalk: 4.1.2
-      css-select: 5.2.2
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      htmlparser2: 8.0.2
-      postcss: 8.5.23
-      postcss-media-query-parser: 0.2.3
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-select@5.2.2:
+  css-select@6.0.0:
     dependencies:
       boolbase: 1.0.0
-      css-what: 6.2.2
+      css-what: 7.0.0
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
 
-  css-what@6.2.2: {}
+  css-what@7.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -3114,6 +3126,8 @@ snapshots:
       tapable: 2.3.3
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -3272,12 +3286,12 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  htmlparser2@8.0.2:
+  htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.2.2
-      entities: 4.5.0
+      entities: 7.0.1
 
   icu-minify@4.13.4:
     dependencies:
@@ -3576,6 +3590,10 @@ snapshots:
   po-parser@2.1.1: {}
 
   postcss-media-query-parser@0.2.3: {}
+
+  postcss-safe-parser@7.0.1(postcss@8.5.23):
+    dependencies:
+      postcss: 8.5.23
 
   postcss@8.5.23:
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "extends": ["github>GSTJ/magic", "helpers:pinGitHubActionDigests"],
   "packageRules": [
     {
-      "description": "The overrides block, now in pnpm-workspace.yaml, pins patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
+      "description": "The overrides block in package.json pins patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
       "matchDepTypes": ["pnpm.overrides"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
`critters` is deprecated. The Nuxt team took the project over and maintains it as `beasties`, so this points the dependency there. Renovate has been flagging it on #118 with no replacement PR available.

## Mechanism

The dependency exists for `experimental.optimizeCss`. Next requires it by name at render time, in `dist/server/post-process.js`, and nothing in `src/` imports it:

```js
process.env.NEXT_RUNTIME !== 'edge' && renderOpts.optimizeCss ? async (html) => {
  const Critters = require('critters');
  const cssOptimizer = new Critters({ ssrMode: true, ... });
```

Next 16.2.12 has no reference to `beasties` anywhere in `dist/`, so depending on `beasties` under its own name leaves that `require` unresolved and the build dies the first time it prerenders a page. `"critters": "npm:beasties@^0.4.3"` keeps the specifier resolving and puts the maintained code behind it. `require("critters")` now returns beasties' CJS build, which exports the constructor directly, the shape `new Critters(...)` needs.

next.config.ts carries a note to drop the alias when Next starts requiring `beasties` by name.

## Proof

![proof](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/fab5d2518299f5aba4f79fc8c8c4ad7d7ed8552f/portfolio/critters-to-beasties/critters-to-beasties.png)

`pnpm lint`, `format`, `typecheck` and `build` all exit 0. Both prerendered pages come out with the same inlined critical CSS as the critters build:

| | critters 0.0.25 | beasties 0.4.3 |
| --- | --- | --- |
| `_not-found.html` | 1 style block, 221 bytes, 1 preload | 1 style block, 221 bytes, 1 preload |
| `_global-error.html` | 1 style block, 888 bytes, 1 preload | 1 style block, 888 bytes, 1 preload |

Only the two `○ (Static)` routes get their HTML written at build time. The locale pages are `ƒ (Dynamic)`, so their CSS is inlined per request through the same code path.

Full logs: https://github.com/GSTJ/pr-assets-dump/tree/portfolio-critters-to-beasties/portfolio/critters-to-beasties

## renovate.json

The packageRule description said the overrides block lives in `pnpm-workspace.yaml`. That was true for about an hour during #146's pnpm 11 attempt, which got reverted. The overrides are in package.json and the rule already matches them there.
