### PR TITLE
refactor: cn/cva classNames, magic@v1, no-manual-classname

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   checkup:
     # Install, build, lint, format and typecheck all come from the shared
     # workflow, so this repo stops carrying its own copy of the steps.
-    uses: GSTJ/magic/.github/workflows/ci.yml@32c29fe042d2bff2d4ed1df5eda8ea7619c9a911 # main
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
     # A called workflow cannot exceed the caller's grant, and this one only
     # reads the tree.
     permissions:

--- a/oxlint.config.mts
+++ b/oxlint.config.mts
@@ -7,7 +7,13 @@ import next from "magic-oxlint-config/next";
 // ignore, so 1.2.0 cannot defend them either and leaves `extends` undocumented.
 // That is why this is not `defineConfig`.
 export default extendConfig(next, {
+  jsPlugins: [{ name: "magic", specifier: "magic-oxlint-plugin" }],
   rules: {
+    // Every class in this repo comes from design-portfolio.css (`ws-*`), and
+    // the components used to splice them together with template literals —
+    // which is exactly the drift this rule exists to stop. Conditionals go
+    // through `cn`, one-of-N tone/side/topic tables through `cva`.
+    "magic/no-manual-classname": "error",
     // next.config.ts sets `reactCompiler: true`, so every component in this
     // repo is compiled with the React Compiler and its props are memoized
     // automatically. These two rules ask for the hand-written useCallback /

--- a/package.json
+++ b/package.json
@@ -16,12 +16,15 @@
   "dependencies": {
     "@next/third-parties": "16.2.12",
     "@vercel/analytics": "2.0.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "16.2.12",
     "next-intl": "4.13.4",
     "postcss": "8.5.23",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-wrap-balancer": "^1.1.1",
+    "tailwind-merge": "^3.6.0",
     "tailwindcss": "4.3.3",
     "typescript": "7.0.2"
   },
@@ -36,6 +39,7 @@
     "magic-codemods": "^1.1.0",
     "magic-oxfmt-config": "^1.2.0",
     "magic-oxlint-config": "^1.2.0",
+    "magic-oxlint-plugin": "^1.1.0",
     "magic-tsconfig": "^1.2.0",
     "oxfmt": "0.60.0",
     "oxlint": "1.75.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,12 @@ importers:
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.2.12(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 16.2.12
         version: 16.2.12(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -49,6 +55,9 @@ importers:
       react-wrap-balancer:
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.8)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -86,6 +95,9 @@ importers:
       magic-oxlint-config:
         specifier: ^1.2.0
         version: 1.2.0(eslint@9.39.5(jiti@2.7.0))(oxlint@1.75.0)
+      magic-oxlint-plugin:
+        specifier: ^1.1.0
+        version: 1.1.0(oxlint@1.75.0)
       magic-tsconfig:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1433,12 +1445,19 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -1820,6 +1839,15 @@ packages:
       oxlint:
         optional: true
 
+  magic-oxlint-plugin@1.1.0:
+    resolution: {integrity: sha512-SdxWuNO9B0g5vMivlk9gP0B+PIKmBoImn8QWn9HQy0tIiyELzSmdrBkGtB2OB7IY23KK6b3gx1WDy8gxy763EA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      oxlint: '>=1.75.0'
+    peerDependenciesMeta:
+      oxlint:
+        optional: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2082,6 +2110,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -3052,6 +3083,10 @@ snapshots:
       mitt: 3.0.1
       zod: 3.25.76
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
 
   cliui@9.0.1:
@@ -3059,6 +3094,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
 
@@ -3416,6 +3453,10 @@ snapshots:
     transitivePeerDependencies:
       - eslint
 
+  magic-oxlint-plugin@1.1.0(oxlint@1.75.0):
+    optionalDependencies:
+      oxlint: 1.75.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3718,6 +3759,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.3: {}
 

--- a/src/components/portfolio/awards.tsx
+++ b/src/components/portfolio/awards.tsx
@@ -1,8 +1,20 @@
+import { cva } from "class-variance-authority";
 import { getTranslations } from "next-intl/server";
 import { Balancer } from "react-wrap-balancer";
 
 import { AWARDS } from "./data";
 import { Eyebrow, richTags } from "./shared";
+
+// Each row is tinted by the metal of the trophy it won.
+const awardsRow = cva("ws-awards-row", {
+  variants: {
+    trophy: {
+      gold: "ws-awards-trophy-gold",
+      silver: "ws-awards-trophy-silver",
+      bronze: "ws-awards-trophy-bronze",
+    },
+  },
+});
 
 export const Awards = async () => {
   const t = await getTranslations("awards");
@@ -17,10 +29,7 @@ export const Awards = async () => {
       </div>
       <ul className="ws-awards-list">
         {AWARDS.map((a) => (
-          <li
-            key={a.id}
-            className={`ws-awards-row ws-awards-trophy-${a.trophy}`}
-          >
+          <li key={a.id} className={awardsRow({ trophy: a.trophy })}>
             <span className="ws-awards-year">{a.year}</span>
             <span className="ws-awards-position">
               {t(`positions.${a.position}`)}

--- a/src/components/portfolio/flourishes.tsx
+++ b/src/components/portfolio/flourishes.tsx
@@ -4,6 +4,8 @@ import type { FlourishKind } from "./data";
 
 import { useCallback, useEffect, useState } from "react";
 
+import { cn } from "@/utils/cn";
+
 type CoinQuote = {
   price: number;
   delta: number;
@@ -103,9 +105,7 @@ const FlourishTicker = ({ hover }: { hover: boolean }) => {
 
 const FlourishFrames = ({ hover }: { hover: boolean }) => {
   return (
-    <div
-      className={`ws-flourish ws-flourish-frames${hover ? " is-hover" : ""}`}
-    >
+    <div className={cn("ws-flourish ws-flourish-frames", hover && "is-hover")}>
       <div className="ws-frame" />
       <div className="ws-frame ws-frame-active">
         <svg viewBox="0 0 24 24" fill="currentColor">
@@ -120,7 +120,7 @@ const FlourishFrames = ({ hover }: { hover: boolean }) => {
 const FlourishSwatches = ({ hover }: { hover: boolean }) => {
   return (
     <div
-      className={`ws-flourish ws-flourish-swatches${hover ? " is-hover" : ""}`}
+      className={cn("ws-flourish ws-flourish-swatches", hover && "is-hover")}
     >
       {SWATCHES.map((swatch) => (
         <div key={swatch.background} className="ws-sw" style={swatch} />
@@ -131,7 +131,7 @@ const FlourishSwatches = ({ hover }: { hover: boolean }) => {
 
 const FlourishSpark = ({ hover }: { hover: boolean }) => {
   return (
-    <div className={`ws-flourish ws-flourish-spark${hover ? " is-hover" : ""}`}>
+    <div className={cn("ws-flourish ws-flourish-spark", hover && "is-hover")}>
       <span className="ws-soc">SOC 2</span>
       <svg viewBox="0 0 90 22" className="ws-spark" preserveAspectRatio="none">
         <polyline
@@ -157,7 +157,7 @@ const FlourishSpark = ({ hover }: { hover: boolean }) => {
 
 const FlourishScoot = ({ hover }: { hover: boolean }) => {
   return (
-    <div className={`ws-flourish ws-flourish-scoot${hover ? " is-hover" : ""}`}>
+    <div className={cn("ws-flourish ws-flourish-scoot", hover && "is-hover")}>
       <span className="ws-scoot-pkg" aria-hidden>
         📦
       </span>
@@ -174,7 +174,7 @@ const FlourishScoot = ({ hover }: { hover: boolean }) => {
 const FlourishMigration = ({ hover }: { hover: boolean }) => {
   return (
     <div
-      className={`ws-flourish ws-flourish-migration${hover ? " is-hover" : ""}`}
+      className={cn("ws-flourish ws-flourish-migration", hover && "is-hover")}
     >
       <span className="ws-mig-tag">Ionic</span>
       <svg
@@ -195,7 +195,7 @@ const FlourishMigration = ({ hover }: { hover: boolean }) => {
 
 const FlourishTools = ({ hover }: { hover: boolean }) => {
   return (
-    <div className={`ws-flourish ws-flourish-tools${hover ? " is-hover" : ""}`}>
+    <div className={cn("ws-flourish ws-flourish-tools", hover && "is-hover")}>
       <svg
         viewBox="0 0 24 24"
         fill="none"

--- a/src/components/portfolio/language-switcher.tsx
+++ b/src/components/portfolio/language-switcher.tsx
@@ -2,6 +2,7 @@
 
 import { useLocale } from "next-intl";
 
+import { cn } from "@/utils/cn";
 import { Link, usePathname } from "@/utils/navigation";
 import { routing } from "@/utils/routing";
 
@@ -19,7 +20,7 @@ export const LanguageSwitcher = () => {
             key={locale}
             href={pathname}
             locale={locale}
-            className={`ws-lang-link${isActive ? " ws-lang-link-active" : ""}`}
+            className={cn("ws-lang-link", isActive && "ws-lang-link-active")}
             aria-current={isActive ? "true" : undefined}
           >
             {label}

--- a/src/components/portfolio/marginalia.tsx
+++ b/src/components/portfolio/marginalia.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 
+import { cva } from "class-variance-authority";
+
 // One-liner handwritten aside (e.g. "← yes, really"). Rotates a few degrees
 // for a notebook-margin feel; hides on small viewports to stay out of the way.
 type MarginaliaProps = {
@@ -8,21 +10,21 @@ type MarginaliaProps = {
   side?: "left" | "right" | "inline"; // default "inline"
 };
 
-const SIDE_CLASS: Record<NonNullable<MarginaliaProps["side"]>, string> = {
-  left: " ws-marginalia-left",
-  right: " ws-marginalia-right",
-  inline: "",
-};
+const marginalia = cva("ws-marginalia", {
+  variants: {
+    side: {
+      left: "ws-marginalia-left",
+      right: "ws-marginalia-right",
+      inline: "",
+    },
+  },
+  defaultVariants: { side: "inline" },
+});
 
-export const Marginalia = ({
-  children,
-  tilt = -4,
-  side = "inline",
-}: MarginaliaProps) => {
-  const className = `ws-marginalia${SIDE_CLASS[side]}`;
+export const Marginalia = ({ children, tilt = -4, side }: MarginaliaProps) => {
   const style = { "--tilt": `${tilt}deg` } as CSSProperties;
   return (
-    <span className={className} style={style}>
+    <span className={marginalia({ side })} style={style}>
       {children}
     </span>
   );

--- a/src/components/portfolio/mark.tsx
+++ b/src/components/portfolio/mark.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
+import { cn } from "@/utils/cn";
+
 // Highlights inline phrases with a sweep of accent-soft (uses
 // the live --color-accent-soft token so it follows palette
 // swaps). Animates from 0 → 100% width when first in view,
@@ -43,7 +45,7 @@ export const Mark = ({ children }: MarkProps) => {
   }, []);
 
   return (
-    <span ref={ref} className={`ws-mark${on ? " is-on" : ""}`}>
+    <span ref={ref} className={cn("ws-mark", on && "is-on")}>
       {children}
     </span>
   );

--- a/src/components/portfolio/nav.tsx
+++ b/src/components/portfolio/nav.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 
 import { useTranslations } from "next-intl";
 
+import { cn } from "@/utils/cn";
+
 import { ArrowRight, BrandMark } from "./shared";
 
 const NAV_LINKS = [
@@ -38,11 +40,11 @@ export const Nav = ({
 
   return (
     <div
-      className={`ws-nav-wrap ws-pdf-hide${scrolled ? " ws-nav-scrolled" : ""}`}
+      className={cn("ws-nav-wrap ws-pdf-hide", scrolled && "ws-nav-scrolled")}
     >
       <nav className="ws-nav">
         <a
-          className={`ws-nav-brand${burst ? " ws-nav-brand-burst" : ""}`}
+          className={cn("ws-nav-brand", burst && "ws-nav-brand-burst")}
           href="#top"
           onClick={(e) => {
             e.preventDefault();
@@ -56,7 +58,10 @@ export const Nav = ({
           {NAV_LINKS.map((l) => (
             <a
               key={l.id}
-              className={`ws-nav-link${active === l.id ? " ws-nav-link-active" : ""}`}
+              className={cn(
+                "ws-nav-link",
+                active === l.id && "ws-nav-link-active",
+              )}
               href={`#${l.id}`}
               onClick={(e) => {
                 e.preventDefault();

--- a/src/components/portfolio/now-playing.tsx
+++ b/src/components/portfolio/now-playing.tsx
@@ -3,7 +3,7 @@ import { Balancer } from "react-wrap-balancer";
 
 import { NOW } from "./data";
 import { currentMonthLabel } from "./lifeline";
-import { Eyebrow, richTags } from "./shared";
+import { chip, Eyebrow, richTags } from "./shared";
 
 export const NowPlaying = async () => {
   const t = await getTranslations("now");
@@ -22,7 +22,7 @@ export const NowPlaying = async () => {
       <ul className="ws-now-list">
         {NOW.map((n) => (
           <li key={n.id} className="ws-now-row">
-            <span className={`ws-chip ws-chip-${n.tone}`}>
+            <span className={chip({ tone: n.tone })}>
               <span className="ws-chip-dot" />
               {tItems(`${n.id}.chip`)}
             </span>

--- a/src/components/portfolio/shared.tsx
+++ b/src/components/portfolio/shared.tsx
@@ -1,6 +1,27 @@
 import type { ReactNode } from "react";
 
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/utils/cn";
+
 export type ChipTone = "neutral" | "ember" | "coral" | "brass" | "teal";
+
+/**
+ * The tone axis of `ws-chip`. Exported because the "now" list builds its own
+ * chip markup around the same classes.
+ */
+export const chip = cva("ws-chip", {
+  variants: {
+    tone: {
+      neutral: "ws-chip-neutral",
+      ember: "ws-chip-ember",
+      coral: "ws-chip-coral",
+      brass: "ws-chip-brass",
+      teal: "ws-chip-teal",
+    },
+  },
+  defaultVariants: { tone: "neutral" },
+});
 
 export const BrandMark = ({
   size = 28,
@@ -42,7 +63,7 @@ export const Eyebrow = ({
   accent?: boolean;
 }) => {
   return (
-    <span className={`ws-eyebrow${accent ? " ws-eyebrow-accent" : ""}`}>
+    <span className={cn("ws-eyebrow", accent && "ws-eyebrow-accent")}>
       {children}
     </span>
   );
@@ -58,7 +79,7 @@ export const Chip = ({
   dot?: boolean;
 }) => {
   return (
-    <span className={`ws-chip ws-chip-${tone}`}>
+    <span className={chip({ tone })}>
       {Boolean(dot) && <span className="ws-chip-dot" />}
       {children}
     </span>

--- a/src/components/portfolio/talks-list.tsx
+++ b/src/components/portfolio/talks-list.tsx
@@ -1,8 +1,28 @@
+import { cva } from "class-variance-authority";
 import { getTranslations } from "next-intl/server";
 import { Balancer } from "react-wrap-balancer";
 
 import { TALKS } from "./data";
 import { ArrowUpRight, Eyebrow, richTags } from "./shared";
+
+// A talk's topic tints both the row and the chip that names it.
+const talksRow = cva("ws-talks-row", {
+  variants: {
+    topic: {
+      leadership: "ws-talks-topic-leadership",
+      tech: "ws-talks-topic-tech",
+    },
+  },
+});
+
+const talksTopicChip = cva("ws-talks-topic-chip", {
+  variants: {
+    topic: {
+      leadership: "ws-talks-topic-chip-leadership",
+      tech: "ws-talks-topic-chip-tech",
+    },
+  },
+});
 
 export const TalksList = async () => {
   const t = await getTranslations("talks");
@@ -18,10 +38,7 @@ export const TalksList = async () => {
       </div>
       <ul className="ws-talks">
         {TALKS.map((talk) => (
-          <li
-            key={talk.id}
-            className={`ws-talks-row ws-talks-topic-${talk.topic}`}
-          >
+          <li key={talk.id} className={talksRow({ topic: talk.topic })}>
             <span className="ws-talks-date">{talk.date}</span>
             <div className="ws-talks-main">
               <div className="ws-talks-title">{tItems(`${talk.id}.title`)}</div>
@@ -29,9 +46,7 @@ export const TalksList = async () => {
                 {tItems(`${talk.id}.description`)}
               </div>
               <div className="ws-talks-venue">
-                <span
-                  className={`ws-talks-topic-chip ws-talks-topic-chip-${talk.topic}`}
-                >
+                <span className={talksTopicChip({ topic: talk.topic })}>
                   {talk.topic === "leadership"
                     ? t("topicLeadership")
                     : t("topicTech")}

--- a/src/components/portfolio/work-grid.tsx
+++ b/src/components/portfolio/work-grid.tsx
@@ -8,13 +8,32 @@ import {
   type ReactNode,
 } from "react";
 
+import { cva } from "class-variance-authority";
 import { useTranslations } from "next-intl";
 import { Balancer } from "react-wrap-balancer";
+
+import { cn } from "@/utils/cn";
 
 import { WORK, type WorkItem } from "./data";
 import { Flourish } from "./flourishes";
 import { Mark } from "./mark";
 import { ArrowUpRight, Eyebrow, richTags, Tag } from "./shared";
+
+/**
+ * A work tile carries the accent of its item's tone, and lifts while the
+ * pointer is inside it.
+ */
+const workCell = cva("ws-work-cell", {
+  variants: {
+    tone: {
+      ember: "ws-work-tone-ember",
+      coral: "ws-work-tone-coral",
+      brass: "ws-work-tone-brass",
+      teal: "ws-work-tone-teal",
+    },
+    hover: { true: "is-hover", false: "" },
+  },
+});
 
 /**
  * The render callback for the `<mark>` tag used inside work blurbs. Defined at
@@ -45,13 +64,19 @@ const HighlightedEyebrow = ({ text }: { text: string }) => (
       <Fragment key={token.key}>
         {!token.first && (
           <span
-            className={`ws-eyebrow-sep${token.isDate ? " ws-eyebrow-sep-date" : ""}`}
+            className={cn(
+              "ws-eyebrow-sep",
+              token.isDate && "ws-eyebrow-sep-date",
+            )}
           >
             {" · "}
           </span>
         )}
         <span
-          className={`ws-eyebrow-token${token.isDate ? " ws-eyebrow-token-date" : ""}`}
+          className={cn(
+            "ws-eyebrow-token",
+            token.isDate && "ws-eyebrow-token-date",
+          )}
         >
           {token.part}
         </span>
@@ -81,9 +106,7 @@ const WorkTile = ({ item }: { item: WorkItem }) => {
       href={item.href}
       target="_blank"
       rel="noreferrer"
-      className={`ws-work-cell ws-work-tone-${item.tone}${
-        hover ? " is-hover" : ""
-      }`}
+      className={workCell({ tone: item.tone, hover })}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       onMouseMove={onMouseMove}

--- a/src/components/portfolio/writing-list.tsx
+++ b/src/components/portfolio/writing-list.tsx
@@ -1,8 +1,21 @@
+import { cva } from "class-variance-authority";
 import { getTranslations } from "next-intl/server";
 import { Balancer } from "react-wrap-balancer";
 
 import { MEDIUM, WRITING_TOPICS } from "./data";
 import { ArrowUpRight, Eyebrow, richTags } from "./shared";
+
+// Topic pills in the Medium callout, one colour per tone.
+const writingTopic = cva("ws-writing-topic", {
+  variants: {
+    tone: {
+      ember: "ws-writing-topic-ember",
+      coral: "ws-writing-topic-coral",
+      brass: "ws-writing-topic-brass",
+      teal: "ws-writing-topic-teal",
+    },
+  },
+});
 
 export const WritingList = async () => {
   const t = await getTranslations("writing");
@@ -52,7 +65,7 @@ export const WritingList = async () => {
             {WRITING_TOPICS.map((topic) => (
               <span
                 key={topic.id}
-                className={`ws-writing-topic ws-writing-topic-${topic.tone}`}
+                className={writingTopic({ tone: topic.tone })}
               >
                 {t(`topics.${topic.id}`)}
               </span>

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,14 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Joins class names, dropping falsy pieces, and lets a later Tailwind utility
+ * beat an earlier one that sets the same property instead of leaving the
+ * winner to stylesheet order.
+ *
+ * Most of this repo's classes are the hand-written `ws-*` ones from
+ * `design-portfolio.css`, which `tailwind-merge` passes through untouched —
+ * it only rewrites classes it recognises as Tailwind utilities, and
+ * `globals.css` does import Tailwind, so those can appear at any point.
+ */
+export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));


### PR DESCRIPTION
Three things, all tooling-side.

**CI ref.** `.github/workflows/ci.yml` called `GSTJ/magic/.github/workflows/ci.yml` at a SHA on magic's `main`. It now calls `@v1`. The inputs it passes (`node-version`, `build-command`, `turbo-cache`) all exist unchanged in the v1 signature.

**Deps.** `magic-oxlint-config` / `magic-oxfmt-config` / `magic-tsconfig` were already on 1.2.0, the current latest; `magic-codemods` on 1.1.0. Added `magic-oxlint-plugin@1.1.0`, plus `clsx`, `tailwind-merge` and `class-variance-authority` for the rewrite below. This repo is pinned to pnpm 10, which has no release quarantine, so there is no `pnpm-workspace.yaml` and no `minimumReleaseAgeExclude` here.

**`magic/no-manual-classname` at error.** 22 violations, all of them the same shape: a template literal with a leading space doing the joining.

```tsx
// before
<a className={`ws-nav-link${active === l.id ? " ws-nav-link-active" : ""}`} />
// after
<a className={cn("ws-nav-link", active === l.id && "ws-nav-link-active")} />
```

`marginalia.tsx` was the one that motivated the rule — a `Record<Side, string>` of class fragments whose leading spaces held the concatenation together. It is a `cva` table now, as are the other one-of-N axes: chip tone (shared with the "now" list), work tile tone + hover, talk topic (row and chip), award trophy, writing topic.

No disables, and nothing wrapped in `cn()` just to quiet the rule — every call takes real arguments. The rendered class strings are identical to before, including the few (`ws-work-tone-ember`, `ws-talks-topic-tech`) that have no CSS rule behind them and did not before either.

`cn` lives in `src/utils/cn.ts`. `tailwind-merge` is a pass-through for the `ws-*` classes that make up nearly all of this repo, but `globals.css` does import Tailwind, so utilities can show up in a `cn` call at any point.

Verified locally: `pnpm install` clean, oxlint 0 diagnostics, `oxfmt --check` clean, `tsc --noEmit` clean, `next build` green. No test suite in this repo.