### PR TITLE
fix(security): pin the curriculum.pdf content type and set response headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,30 +8,35 @@ const createNextIntl = withNextIntl(
 );
 
 /**
- * Where the generated assets live. `demo.gif` and `curriculum.pdf` are built by
- * the `Generate static files` workflow and uploaded to the `portfolio-assets`
- * R2 bucket, so neither binary is committed here. The only other references are
- * that workflow's upload step and README's `<img src>`.
+ * Applied to every response. None of these depend on the page, so they live
+ * here rather than in the middleware, which only does locale routing.
+ *
+ * No `Content-Security-Policy` yet. The page loads GTM, Google Fonts, PostHog
+ * and Vercel Analytics, so a useful policy is an allowlist that has to be
+ * verified against the real deploy, not a line added blind. `frame-ancestors`
+ * is the part worth having today and `X-Frame-Options` already covers it.
  */
-const ASSETS_ORIGIN =
-  process.env.ASSETS_ORIGIN ?? "https://assets.gabrieltaveira.dev";
+const SECURITY_HEADERS = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+];
 
 const nextConfig = {
   devIndicators: false,
   reactCompiler: true,
-  /**
-   * The resume keeps its own URL. Metadata and the download link both point at
-   * `/curriculum.pdf`, so this proxies rather than redirects. R2 already
-   * answers with `application/pdf`, an ETag and a cache-control the workflow
-   * sets, and Next hands those through untouched.
-   */
-  rewrites: () =>
-    Promise.resolve([
-      {
-        source: "/curriculum.pdf",
-        destination: `${ASSETS_ORIGIN}/curriculum.pdf`,
-      },
-    ]),
+  /** `X-Powered-By: Next.js` tells an attacker which CVEs to try. */
+  poweredByHeader: false,
+  headers: () =>
+    Promise.resolve([{ source: "/(.*)", headers: SECURITY_HEADERS }]),
   experimental: {
     /**
      * Next inlines critical CSS with a literal `require("critters")` in

--- a/src/app/curriculum.pdf/route.ts
+++ b/src/app/curriculum.pdf/route.ts
@@ -1,0 +1,62 @@
+/**
+ * The resume keeps its own URL on this origin. `demo.gif` and `curriculum.pdf`
+ * are built by the `Generate static files` workflow and uploaded to the
+ * `portfolio-assets` R2 bucket, so neither binary is committed here.
+ *
+ * This used to be a `rewrites()` entry pointing at R2. A rewrite passes the
+ * upstream response through untouched, `Content-Type` included, which means
+ * whoever can write that bucket object decides what type `gabrieltaveira.dev`
+ * serves. Flip it to `text/html` and the browser renders attacker HTML at
+ * `https://gabrieltaveira.dev/curriculum.pdf`, same origin as the site: stored
+ * XSS, not a defaced PDF. Re-emitting the bytes here pins the type in code,
+ * where the bucket cannot reach it, and drops the upstream's other headers
+ * instead of forwarding them verbatim.
+ */
+const ASSETS_ORIGIN =
+  process.env.ASSETS_ORIGIN ?? "https://assets.gabrieltaveira.dev";
+
+/** Matches what the workflow uploads and what the old rewrite served. */
+const PDF_CACHE_CONTROL = "public, max-age=14400, s-maxage=14400";
+
+/**
+ * Dynamic on purpose. Prerendering this would make every deploy depend on R2
+ * being reachable at build time, and the CDN already absorbs the traffic via
+ * `s-maxage` — one upstream hit per region per four hours.
+ */
+export const dynamic = "force-dynamic";
+
+function unavailable() {
+  return new Response("Resume unavailable", {
+    status: 502,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}
+
+export async function GET() {
+  let upstream: Response;
+
+  try {
+    upstream = await fetch(`${ASSETS_ORIGIN}/curriculum.pdf`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    // R2 unreachable or too slow. A 502 beats a 500 with a stack trace.
+    return unavailable();
+  }
+
+  if (!upstream.ok) return unavailable();
+
+  return new Response(upstream.body, {
+    status: 200,
+    /**
+     * Built from scratch rather than copied off `upstream.headers`. Only these
+     * four reach the client, and every value is a literal.
+     */
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": 'inline; filename="gabriel-taveira.pdf"',
+      "Cache-Control": PDF_CACHE_CONTROL,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}


### PR DESCRIPTION
Replaces the `/curriculum.pdf` rewrite with a route handler that sets `Content-Type` in code, and adds the response headers the site was missing.

## Problem

`/curriculum.pdf` was a `rewrites()` entry pointing at the R2 bucket. A rewrite proxies, so the upstream's `Content-Type` comes back untouched, which means whoever can write that bucket object decides what type `gabrieltaveira.dev` serves.

Write `text/html` over `curriculum.pdf` and the browser renders attacker HTML at `https://gabrieltaveira.dev/curriculum.pdf`. Same origin as the site, so it's stored XSS for anyone with R2 write access or control of the `assets.gabrieltaveira.dev` record. It needs credentials, so there's no anonymous path to it today, and there was no CSP or `nosniff` behind it to limit the damage if there were.

I reproduced it against a local origin that answers `text/html` for that path, standing in for a compromised bucket. Left side is `main`.

<img src="https://raw.githubusercontent.com/GSTJ/pr-assets-dump/portfolio-response-headers-proof/pdf-hijack-proof.png" width="900" alt="before and after against a malicious upstream" />

Worth closing even so, because `CLOUDFLARE_API_TOKEN` lives in a workflow that also runs `pnpm install` with lifecycle scripts enabled for puppeteer, `@swc/core`, esbuild and workerd, plus `PabloLec/website-to-gif`. That action is SHA-pinned, the postinstall scripts aren't.

## Fix

`src/app/curriculum.pdf/route.ts` streams the bytes and builds the response from scratch: `Content-Type: application/pdf`, `Content-Disposition: inline; filename="gabriel-taveira.pdf"`, `Cache-Control: public, max-age=14400, s-maxage=14400`, `X-Content-Type-Options: nosniff`, and nothing forwarded. So the upstream's `x-upstream`/`cf-*`/`cache-control` stop leaking through. The `nosniff` is duplicated from the site-wide list below on purpose, so scoping that list later can't quietly un-harden this one route.

It stays dynamic. Prerendering it made the route show up as `○ (Static)`, and every deploy would start depending on R2 being up at build time. `s-maxage=14400` gives the CDN one upstream hit per region per four hours, matching the `max-age=14400` R2 was already sending.

Also adds the headers the site never had:

```
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
```

Plus `poweredByHeader: false`. `.next/routes-manifest.json` had `"headers": []` before this.

`nosniff` makes the browser refuse a script whose MIME type isn't executable. Locally that turns the Vercel Analytics 404 into a console error, because the dev server answers `text/html` for `/_vercel/insights/script.js`. Production answers `200 application/javascript`, which I checked against www.gabrieltaveira.dev, and I'll confirm it again on the preview deploy.

No CSP in here. It gets its own PR with report-only running first, since GTM, Google Fonts, PostHog and Vercel Analytics all need allowlisting and a policy written blind either breaks the site or ends up allowlisting everything. That being said, `script-src` is the directive that would have contained the bug above, so it's the next PR after this one. `frame-ancestors` is already covered by `X-Frame-Options`.

## Checks

`build`, `typecheck`, `lint` and `format` all clean locally. Real R2 still returns the actual resume: 715194 bytes, `PDF document, version 1.5, 1 pages`. Page renders unchanged, and the only console error is the dev-server Analytics 404 described above:

<img src="https://raw.githubusercontent.com/GSTJ/pr-assets-dump/portfolio-response-headers-proof/local-site-headers.png" width="900" alt="site rendering unchanged with the new headers" />
