### PR TITLE
fix: drop the dead youtube cron and harden three input paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to my open-source portfolio! This project is built using Next.js, Tailwi
 - Responsive design with Tailwind CSS
 - Dark mode support
 - Server Components for improved performance
-- Integration with Youtube's API for up-to-date information on the latest Space Cast episode.
+- A live COIN quote on the hero, served from `/api/coin` with a cached fallback
 
 ## Getting Started
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,7 +8,10 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 
 import { ObservabilityProviders } from "@/components/observability/providers";
-import { buildPortfolioJsonLd } from "@/components/portfolio/structured-data";
+import {
+  buildPortfolioJsonLd,
+  serializeJsonLd,
+} from "@/components/portfolio/structured-data";
 import { routing } from "@/utils/routing";
 
 const SITE_URL = "https://gabrieltaveira.dev";
@@ -109,13 +112,13 @@ const LocaleLayout = async ({
         />
         <script
           type="application/ld+json"
-          // eslint-disable-next-line react/no-danger -- JSON-LD has no React representation, so a raw script body is the only way to emit it, and the payload is JSON.stringify of an object this file builds.
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(person) }}
+          // eslint-disable-next-line react/no-danger -- JSON-LD has no React representation, so a raw script body is the only way to emit it. serializeJsonLd escapes `<` so the payload cannot close this tag.
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(person) }}
         />
         <script
           type="application/ld+json"
           // eslint-disable-next-line react/no-danger -- same as above.
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(profilePage) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(profilePage) }}
         />
       </head>
       <GoogleTagManager gtmId={GTM_ID} />

--- a/src/app/api/coin/route.ts
+++ b/src/app/api/coin/route.ts
@@ -26,6 +26,9 @@ export async function GET() {
       "https://query1.finance.yahoo.com/v8/finance/chart/COIN?interval=1d&range=1d",
       {
         next: { revalidate: 300 },
+        // Without this a hung Yahoo holds the function open until Vercel's own
+        // timeout. The catch below already answers 200 with the stale price.
+        signal: AbortSignal.timeout(3000),
         headers: {
           // Yahoo sometimes 401s requests without a UA.
           "User-Agent":

--- a/src/components/portfolio/structured-data.ts
+++ b/src/components/portfolio/structured-data.ts
@@ -106,3 +106,19 @@ export function buildPortfolioJsonLd(locale: string): PortfolioJsonLd {
 
   return { person, profilePage };
 }
+
+/**
+ * `JSON.stringify` escapes quotes and backslashes but leaves `<` alone, so a
+ * value containing a closing script tag ends the tag it is sitting inside and
+ * everything after it gets parsed as HTML.
+ *
+ * Nothing hostile can reach that today: every input is a module constant, and
+ * `locale` is checked against `routing.locales` in `[locale]/layout.tsx`
+ * before this runs. That guard lives in another file though, and nothing
+ * enforces the ordering. The escape is valid JSON and parses straight back to
+ * `<`, so it costs nothing and stops the sink depending on a check it cannot
+ * see.
+ */
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replaceAll("<", String.raw`\u003c`);
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,12 +1,28 @@
+import { hasLocale } from "next-intl";
 import { getRequestConfig } from "next-intl/server";
 
+import { routing } from "../utils/routing";
+
 export default getRequestConfig(async ({ requestLocale }) => {
-  // Default to English if no locale is provided
-  const currentLocale = (await requestLocale) ?? "en-US";
-  const messages = await import(`./locales/${currentLocale}.json`);
+  const requested = await requestLocale;
+
+  /**
+   * `requested` comes off the URL. Nothing upstream of here guarantees it is
+   * one of ours: the middleware matcher skips any path containing a dot, so
+   * `/evil.json` reaches this config un-normalised, and the value is then
+   * interpolated into an `import()`. Webpack's context module and the
+   * `notFound()` in `[locale]/layout.tsx` both happen to block that today,
+   * which makes this safe by accident rather than by construction. Falling
+   * back to the default locale is what next-intl asks for.
+   */
+  const locale = hasLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale;
+
+  const messages = await import(`./locales/${locale}.json`);
 
   return {
-    locale: currentLocale,
+    locale,
     messages: messages.default,
   };
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron?key=plsRefetchYoutubeData",
-      "schedule": "30 11 * * 3"
-    }
-  ]
-}


### PR DESCRIPTION
Deletes `vercel.json` and tightens three things that were safe by accident.

## The cron

`vercel.json` scheduled `/api/cron?key=plsRefetchYoutubeData` for 11:30 UTC every Wednesday. That route doesn't exist. `src/api/cron.ts` was deleted in #44 on 2025-06-11 and the schedule stayed behind, so it's been firing into a 404 every Wednesday for about 13 months. `src/app/api` now contains exactly one file, `coin/route.ts`, and production confirms the 404. README still advertised the YouTube integration, which is fixed here too.

`crons` was the only key in the file, so the file goes.

The `key=` is the part I'd want gone even if the route came back. It's a shared secret committed to a public repo and passed in a query string, so it would also sit in Vercel's request logs and every CDN log in front of them. Vercel already signs its own cron calls with `Authorization: Bearer $CRON_SECRET`, so a query-string key is the worse version of something that already exists.

## Two sinks that were guarded from another file

Neither is reachable today.

`serializeJsonLd` escapes `<` before the payload reaches `dangerouslySetInnerHTML` in `[locale]/layout.tsx`. `JSON.stringify` escapes quotes and backslashes but leaves `<` alone, so a value containing a closing script tag ends the tag it's sitting in. Every input is a module constant right now and `locale` is checked before the call, but the check is in another file and nothing enforces the ordering.

`src/i18n/index.ts` now runs `hasLocale(routing.locales, requested)` before interpolating the locale into `import()`. The middleware matcher skips any path containing a dot, so `/evil.json` was reaching this un-normalised; what actually stopped it was webpack's context module plus the `notFound()` in the layout. next-intl asks for this guard in its own docs.

## One timeout

`/api/coin` gets `AbortSignal.timeout(3000)`. The outbound Yahoo fetch had no timeout, so a hung upstream would hold the function open until Vercel's max duration cut it off. I haven't seen it happen, and `next: { revalidate: 300 }` bounds it to roughly one slow invocation per region per five minutes, which is probably why. The existing `catch` already answers 200 with the stale price, so the abort lands somewhere that handles it.

## Checks

<img src="https://raw.githubusercontent.com/GSTJ/pr-assets-dump/portfolio-input-hardening-proof/inputs-proof.png" width="900" alt="cron 404, json-ld escaping, and locale route probes" />

`build`, `typecheck`, `lint` and `format` clean. The escaping check lifts the line straight out of `structured-data.ts`, so it can't pass against a version of the code that isn't shipping.
