### PR TITLE
fix(seo): point every public URL at the host that serves

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Contributions are welcome! If you find a bug or have a suggestion, please create
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-Made with ❤️ by [Gabriel Taveira](www.gabrieltaveira.dev).
+Made with ❤️ by [Gabriel Taveira](https://www.gabrieltaveira.dev).

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,8 +13,8 @@ import {
   serializeJsonLd,
 } from "@/components/portfolio/structured-data";
 import { routing } from "@/utils/routing";
+import { SITE_URL } from "@/utils/site";
 
-const SITE_URL = "https://gabrieltaveira.dev";
 const GTM_ID = "G-1S8PR4TDYM";
 
 /**

--- a/src/app/api/coin/route.ts
+++ b/src/app/api/coin/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
         headers: {
           // Yahoo sometimes 401s requests without a UA.
           "User-Agent":
-            "Mozilla/5.0 (compatible; portfolio-ticker/1.0; +https://gabrieltaveira.com)",
+            "Mozilla/5.0 (compatible; portfolio-ticker/1.0; +https://www.gabrieltaveira.dev)",
           Accept: "application/json",
         },
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import "@total-typescript/ts-reset";
 import "./globals.css";
 import type { Metadata } from "next";
 
+import { SITE_URL } from "@/utils/site";
+
 /**
  * Root layout. The `<html>` and `<body>` shells live in
  * `src/app/[locale]/layout.tsx` so that `<html lang>` reflects the active
@@ -10,7 +12,7 @@ import type { Metadata } from "next";
  */
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://gabrieltaveira.dev"),
+  metadataBase: new URL(SITE_URL),
 };
 
 export default function RootLayout({ children }: React.PropsWithChildren) {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,16 @@
 import type { MetadataRoute } from "next";
 
-const SITE_URL = "https://gabrieltaveira.dev";
+import { SITE_URL } from "@/utils/site";
 
+/**
+ * No `host`. That directive is Yandex's, Yandex dropped support for it in 2018,
+ * and no other crawler ever read it, so the line only ever named a host for
+ * nobody. `sitemap` and the canonical links carry the same information to
+ * crawlers that act on it.
+ */
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },
     sitemap: `${SITE_URL}/sitemap.xml`,
-    host: SITE_URL,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,17 +1,17 @@
 import type { MetadataRoute } from "next";
 
 import { routing } from "@/utils/routing";
+import { SITE_URL } from "@/utils/site";
 
-const SITE_URL = "https://gabrieltaveira.dev";
+/** The hreflang cluster for one path, every locale pointing at every other. */
+const languages = (path: string) =>
+  Object.fromEntries(
+    routing.locales.map((l) => [l, `${SITE_URL}/${l}${path}`]),
+  );
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const routes: MetadataRoute.Sitemap = [];
-
-  const languages = (path: string) =>
-    Object.fromEntries(
-      routing.locales.map((l) => [l, `${SITE_URL}/${l}${path}`]),
-    );
 
   for (const locale of routing.locales) {
     routes.push(

--- a/src/components/portfolio/structured-data.ts
+++ b/src/components/portfolio/structured-data.ts
@@ -6,10 +6,11 @@
  * into the initial HTML via a `<script type="application/ld+json">` tag.
  */
 
+import { SITE_URL } from "@/utils/site";
+
 import { CHANNELS, EMAIL_ADDR, GITHUB, LINKEDIN, MEDIUM, WORK } from "./data";
 import { yearsInIndustry } from "./lifeline";
 
-const SITE_URL = "https://gabrieltaveira.dev";
 const KNOWS_ABOUT_CAP = 15;
 
 /**

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,0 +1,18 @@
+/**
+ * The one host the site is reachable on. Vercel holds
+ * `www.gabrieltaveira.dev` as the project's primary domain, so the apex
+ * answers `308 -> https://www.gabrieltaveira.dev/` and nothing is ever served
+ * from it.
+ *
+ * Every public URL the app emits is built from this: the canonical link, the
+ * hreflang cluster, `og:url`, the sitemap entries and the JSON-LD `url`. They
+ * used to be five separate copies of the apex, which meant every one of them
+ * named a URL that redirects. Google resolves a canonical through its redirect
+ * and indexes the target instead, so the declared canonical was discarded, and
+ * an hreflang entry that redirects drops out of the cluster it was supposed to
+ * join.
+ *
+ * If the primary domain in Vercel ever moves back to the apex, this constant
+ * is the only line that changes.
+ */
+export const SITE_URL = "https://www.gabrieltaveira.dev";


### PR DESCRIPTION
Every canonical, hreflang, `og:url`, sitemap entry and JSON-LD `url` pointed at `https://gabrieltaveira.dev`. Nothing is served from that host. Vercel holds `www.gabrieltaveira.dev` as the project's primary domain, so the apex answers a 308:

```
$ curl -sI https://gabrieltaveira.dev/
HTTP/2 308
location: https://www.gabrieltaveira.dev/
```

Google resolves a canonical through its redirect and indexes the target instead, so the apex canonical did nothing. The hreflang cluster has the same problem: an alternate that redirects gets dropped, and both locales were redirecting. All four sitemap `<loc>` entries were redirects too.

Now it's `https://www.gabrieltaveira.dev` everywhere, out of one constant in `src/utils/site.ts`. The string used to be copied five times: root layout `metadataBase`, locale layout, `robots.ts`, `sitemap.ts`, `structured-data.ts`.

I also dropped `host` from `robots.ts`. Yandex removed support for that directive in 2018.

The COIN ticker's User-Agent advertised `+https://gabrieltaveira.com`, the wrong TLD. The README footer link was `[Gabriel Taveira](www.gabrieltaveira.dev)` with no scheme, so GitHub resolved it as a repo-relative path. Both point at www now.

`languages()` in `sitemap.ts` moved to module scope. It stopped closing over anything once `SITE_URL` became an import, and `unicorn/consistent-function-scoping` flags that.

If you'd rather the apex be the host, the fix goes the other way: switch the primary domain in Vercel and point `SITE_URL` back. I matched what's serving today.

## Proof

Local production build (`pnpm build && pnpm start`), every URL read back off the running server.

<img src="https://raw.githubusercontent.com/GSTJ/pr-assets-dump/a0b5f2bd505ad92f76bcd46b46a30769166da0ac/gabriel-taveira-portfolio/canonical-host/emitted-urls.png" width="920">

Home page from that same build:

<img src="https://raw.githubusercontent.com/GSTJ/pr-assets-dump/a0b5f2bd505ad92f76bcd46b46a30769166da0ac/gabriel-taveira-portfolio/canonical-host/home.png" width="920">

`pnpm lint`, `pnpm format`, `pnpm typecheck` and `pnpm build` all pass locally.

https://claude.ai/code/session_019CvXsee9MpRqkY1Xri9hMk
