### PR TITLE
docs: correct two claims the repo no longer matches

### DIFF
--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -95,8 +95,13 @@ jobs:
           url: "https://www.gabrieltaveira.dev"
 
       # Straight to R2, no commit and no branch. Both objects are overwritten in
-      # place and served from the custom domain, which README links to directly
-      # and which next.config.ts proxies /curriculum.pdf onto.
+      # place and served from the custom domain, which README links to directly.
+      # `curriculum.pdf` also reaches the site's own origin through
+      # `src/app/curriculum.pdf/route.ts`, which refetches it from here and
+      # re-emits the bytes under a Content-Type pinned in code. It used to be a
+      # `next.config.ts` rewrite, and a rewrite forwards the upstream
+      # Content-Type, which handed whoever can write this object the power to
+      # decide what gabrieltaveira.dev serves.
       #
       # --remote is not optional. Without it wrangler v4 writes to a local
       # simulation on the runner, reports success, and uploads nothing.

--- a/README.md
+++ b/README.md
@@ -55,21 +55,14 @@ Open your browser and navigate to http://localhost:3000 to see the portfolio in 
 
 ### Deployment
 
-To deploy this project to production, follow these steps:
+Production runs on Vercel, deployed from `main` on every push. `www.gabrieltaveira.dev` is the primary domain and the apex redirects onto it, which is where `src/utils/site.ts` gets its host.
 
-1. Build the project for production:
+There is no static export. The locale routing runs in `src/proxy.ts`, `/api/coin` and `/curriculum.pdf` are route handlers, and both locale pages render on demand, so the build needs a Node server rather than a folder of files:
 
 ```sh
 pnpm build
-```
-
-2. Start the production server:
-
-```sh
 pnpm start
 ```
-
-Deploy the out folder to your preferred hosting provider.
 
 ### Contributing
 


### PR DESCRIPTION
I rewrote the README's Deployment section and one comment in `generate-files.yml`. Both described a setup this repo no longer has.

The README ended with "Deploy the out folder to your preferred hosting provider". Nothing is statically exported: locale routing runs in `src/proxy.ts`, `/api/coin` and `/curriculum.pdf` are route handlers, and both locale pages render on demand. The section now says production runs on Vercel from `main` and that the build needs a Node server.

`generate-files.yml` said `next.config.ts` proxies `/curriculum.pdf` onto the R2 domain. #163 replaced that rewrite with `src/app/curriculum.pdf/route.ts`, which refetches the object and re-emits it with a Content-Type pinned in code. I pointed the comment at the route handler and kept the reason for the swap: a rewrite forwards the upstream Content-Type, which lets whoever can write the R2 object choose what the site serves.

Comments and prose only. `pnpm lint`, `pnpm format` and `pnpm typecheck` pass locally.

https://claude.ai/code/session_019CvXsee9MpRqkY1Xri9hMk
