### PR TITLE
fix(deps): restore pnpm security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,31 +50,5 @@
     "puppeteer": "^25.0.0",
     "wrangler": "4.116.0"
   },
-  "packageManager": "pnpm@10.34.5",
-  "pnpm": {
-    "overrides": {
-      "@babel/core": "^7.29.6",
-      "ajv@6": "^6.14.0",
-      "brace-expansion@1": "^1.1.16",
-      "brace-expansion@2": "^2.1.2",
-      "brace-expansion@5": "^5.0.8",
-      "flatted": "^3.4.2",
-      "postcss": "^8.5.18",
-      "js-yaml@3": "^3.15.0",
-      "js-yaml@4": "^4.3.0",
-      "lodash": "^4.18.0",
-      "minimatch@3": "^3.1.3",
-      "minimatch@9": "^9.0.7",
-      "picomatch@2": "^2.3.2",
-      "sharp": "^0.35.0",
-      "ws": "^8.21.0"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@swc/core",
-      "esbuild",
-      "puppeteer",
-      "workerd"
-    ]
-  }
+  "packageManager": "pnpm@10.34.5"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,26 @@
+packages:
+  - "."
+
+overrides:
+  "@babel/core": "^7.29.6"
+  "ajv@6": "^6.14.0"
+  "brace-expansion@1": "^1.1.16"
+  "brace-expansion@2": "^2.1.2"
+  "brace-expansion@5": "^5.0.8"
+  flatted: "^3.4.2"
+  postcss: "^8.5.18"
+  "js-yaml@3": "^3.15.0"
+  "js-yaml@4": "^4.3.0"
+  lodash: "^4.18.0"
+  "minimatch@3": "^3.1.3"
+  "minimatch@9": "^9.0.7"
+  "picomatch@2": "^2.3.2"
+  sharp: "^0.35.0"
+  ws: "^8.21.0"
+
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@swc/core"
+  - esbuild
+  - puppeteer
+  - workerd

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "extends": ["github>GSTJ/magic", "helpers:pinGitHubActionDigests"],
   "packageRules": [
     {
-      "description": "The overrides block in package.json pins patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
+      "description": "The overrides in pnpm-workspace.yaml pin patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
       "matchDepTypes": ["pnpm.overrides"],
       "matchUpdateTypes": ["major"],
       "enabled": false

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "PUPPETEER_SKIP_DOWNLOAD=true corepack pnpm@10.34.5 install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary

Moves pnpm's security overrides and build-script allowlist into the project config that pnpm 10 reads.

## Details

- pnpm 10.34.5 was ignoring both settings in `package.json` and warning on every command.
- Keeps the same 15 patched dependency ranges and five allowed build dependencies. The lockfile and resolved versions stay unchanged.
- Declares the root package explicitly so Vercel's workspace detector includes the app.
- Pins Vercel installs to pnpm 10.34.5 and skips the browser download that only the asset-generation workflow needs.
- Updates Renovate's override note to point at `pnpm-workspace.yaml`.

## Testing steps

1. Run:

```sh
PUPPETEER_SKIP_DOWNLOAD=true corepack pnpm@10.34.5 install --frozen-lockfile
```

The install should finish without the warning that the `pnpm` field is ignored.

2. Run:

```sh
pnpm config get overrides --json
pnpm config get onlyBuiltDependencies --json
```

The output should list 15 overrides and five allowed build dependencies.

3. Run:

```sh
pnpm audit --audit-level=low
pnpm run lint
pnpm run format
pnpm run typecheck
pnpm run build
```

The audit should report no known vulnerabilities, and every project check should exit successfully.

4. Start the production build:

```sh
PORT=3100 pnpm start
```

Open `http://localhost:3100/en-US` and confirm the portfolio renders at mobile and desktop sizes.

![Mobile production build](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/portfolio-pnpm-config-20260802/evidence/portfolio-pnpm-config/mobile.png)

![Desktop production build](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/portfolio-pnpm-config-20260802/evidence/portfolio-pnpm-config/desktop.png)
