### PR TITLE
fix(security): clear development audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   ajv@6: ^6.14.0
   brace-expansion@1: ^1.1.16
   brace-expansion@2: ^2.1.2
-  brace-expansion@5: ^5.0.8
+  brace-expansion@5: ^5.0.9
   flatted: ^3.4.2
   postcss: ^8.5.18
   js-yaml@3: ^3.15.0
@@ -19,6 +19,7 @@ overrides:
   minimatch@9: ^9.0.7
   picomatch@2: ^2.3.2
   sharp: ^0.35.0
+  undici@7: ^7.29.0
   ws: ^8.21.0
 
 importers:
@@ -1458,8 +1459,8 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   callsites@3.1.0:
@@ -2231,8 +2232,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3166,7 +3167,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3577,7 +3578,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@26.1.2)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260730.1
       ws: 8.21.1
       youch: 4.1.0-beta.10
@@ -3588,7 +3589,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -3945,7 +3946,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ overrides:
   "ajv@6": "^6.14.0"
   "brace-expansion@1": "^1.1.16"
   "brace-expansion@2": "^2.1.2"
-  "brace-expansion@5": "^5.0.8"
+  "brace-expansion@5": "^5.0.9"
   flatted: "^3.4.2"
   postcss: "^8.5.18"
   "js-yaml@3": "^3.15.0"
@@ -16,6 +16,7 @@ overrides:
   "minimatch@9": "^9.0.7"
   "picomatch@2": "^2.3.2"
   sharp: "^0.35.0"
+  "undici@7": "^7.29.0"
   ws: "^8.21.0"
 
 onlyBuiltDependencies:


### PR DESCRIPTION
## Summary

We updated the development dependency graph to clear the current security audit.

## Details

- Raises `brace-expansion` from 5.0.8 to 5.0.9 in the `magic-codemods` dependency chain.
- Raises `undici` from 7.28.0 to 7.29.0 in the `wrangler` dependency chain.

## Testing steps

```sh
pnpm install --frozen-lockfile
pnpm audit
pnpm run build
```

The audit should report no known vulnerabilities, and the production build should complete.
