### PR TITLE
fix(renovate): match pnpm workspace overrides

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "packageRules": [
     {
       "description": "The overrides in pnpm-workspace.yaml pin patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",
-      "matchDepTypes": ["pnpm.overrides"],
+      "matchDepTypes": ["pnpm-workspace.overrides"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

Renovate now applies the existing major-update block to compatibility pins in the workspace file.

## Details

- Changes the rule dependency type from `pnpm.overrides` to `pnpm-workspace.overrides`.
- Uses the dependency type Renovate extracts from overrides in `pnpm-workspace.yaml`.
- Keeps patch and minor updates eligible for normal update PRs.

## Testing steps

```sh
pnpm dlx --package renovate@44.3.2 renovate-config-validator renovate.json
pnpm install --frozen-lockfile
pnpm audit
pnpm run build
```

All four commands should exit successfully. The audit should report no known vulnerabilities.
