### PR TITLE
revert(deps): keep pnpm on patched v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "puppeteer": "^25.0.0",
     "wrangler": "4.118.0"
   },
-  "packageManager": "pnpm@11.8.0"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,7 +88,8 @@ minimumReleaseAgeExclude:
   - "@types/react-dom@19.2.4"
   - acorn@8.18.0
   - baseline-browser-mapping@2.11.3
-  - brace-expansion@1.1.18 || 5.0.9
+  - brace-expansion@1.1.18
+  - brace-expansion@5.0.9
   - dompurify@3.4.13
   - eslint-plugin-safe-jsx@1.3.0
   - flatted@3.4.4
@@ -111,12 +112,9 @@ minimumReleaseAgeExclude:
   - workerd@1.20260730.1
   - wrangler@4.118.0
   - yargs@18.1.0
-  # Renovate security update: pnpm@11.8.0
-  - pnpm@11.8.0
-allowBuilds:
-  "@parcel/watcher": true
-  "@swc/core": true
-  core-js: false
-  esbuild: true
-  puppeteer: true
-  workerd: true
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@swc/core"
+  - esbuild
+  - puppeteer
+  - workerd

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Actions are pinned by commit digest with the version in a trailing comment, so a retagged release cannot change what runs. helpers:pinGitHubActionDigests keeps that true for actions added later, and renovate bumps the digest and the comment together.",
   "extends": ["github>GSTJ/magic", "helpers:pinGitHubActionDigests"],
+  "osvVulnerabilityAlerts": false,
   "packageRules": [
     {
       "description": "The overrides in pnpm-workspace.yaml pin patched releases within a major line. Patch and minor bumps keep those pins current; a major rewrites what the override means and breaks the consumers it was pinning.",


### PR DESCRIPTION
## Summary

Reverts #215 and #218. pnpm 10.34.5 is already patched for GHSA-gj8w-mvpf-x27x, so the cross-major security updates were unnecessary.

## Details

- Restores pnpm 10.34.5 and its v10 build-policy syntax.
- Disables the experimental OSV feed that produced the false positive. GitHub vulnerability alerts stay enabled.

## Testing steps

1. Check out this branch.
2. Run:

```sh
corepack pnpm install --frozen-lockfile
corepack pnpm run format
corepack pnpm run lint
corepack pnpm run typecheck
corepack pnpm run build
corepack pnpm audit --audit-level=low
npm audit signatures
jq empty renovate.json
git diff --check
```

3. Confirm every command exits successfully.

![Local pnpm 10 checks](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/e3af1ea0148b7744d9281f7ea909df2f64696d19/portfolio/renovate-20260804/pnpm-10-revert.png)