### PR TITLE
fix(ci): validate hidden Renovate branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+      # Renovate waits for this workflow before it opens a PR, so its hidden
+      # branches need the same validation path as normal pull requests.
+      - "renovate/**"
   # For re-running verify by hand without pushing anything.
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Renovate can now collect branch checks before it opens an eligible dependency PR.

## Details

- CI runs whenever a Renovate branch gets a new commit, while the existing main and pull request triggers stay unchanged.
- The pre-PR gate receives the required lint, format, typecheck, and final verification results.

## Testing steps

1. Open Actions, select CI, and choose the latest Push run for Renovate's magic tooling update.
2. Confirm every item in the run completed successfully.
3. Open the Dependency Dashboard and confirm the magic tooling update moved out of Pending Status Checks.