### PR TITLE
fix(security): pin patched nanoid

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   lodash: ^4.18.0
   minimatch@3: ^3.1.3
   minimatch@9: ^9.0.7
+  nanoid@3: ^3.3.17
   picomatch@2: ^2.3.2
   sharp: ^0.35.0
   undici@7: ^7.29.0
@@ -1932,8 +1933,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3601,7 +3602,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -3749,7 +3750,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ overrides:
   lodash: "^4.18.0"
   "minimatch@3": "^3.1.3"
   "minimatch@9": "^9.0.7"
+  "nanoid@3": "^3.3.17"
   "picomatch@2": "^2.3.2"
   sharp: "^0.35.0"
   "undici@7": "^7.29.0"
@@ -96,6 +97,7 @@ minimumReleaseAgeExclude:
   - icu-minify@4.13.4
   - js-yaml@4.3.1
   - miniflare@5.20260730.0-alpha
+  - nanoid@3.3.17
   - next@16.2.12
   - next-intl@4.13.4
   - next-intl-swc-plugin-extractor@4.13.4


### PR DESCRIPTION
## Summary

Pins Nano ID 3.x to 3.3.17, removing GHSA-2v37-7h3g-55p8 from the production dependency tree.

## Details

- Adds a targeted pnpm override for the first patched 3.x release.
- Lets the security release bypass the repository's 14-day package quarantine.
- Regenerates the lockfile so PostCSS resolves Nano ID 3.3.17.
- The site does not call the affected custom generator APIs. PostCSS uses Nano ID with a constant positive size.

## Testing steps

1. Install the locked dependencies and run the checks:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run format
   pnpm run lint
   pnpm run typecheck
   pnpm run build
   pnpm audit --audit-level low
   ```

   The build should complete and the audit should report no known vulnerabilities.

2. Start the production build:

   ```sh
   pnpm start
   ```

3. Open the homepage and links page. Both should load normally at desktop and mobile sizes.

![Desktop homepage](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/nanoid-security-f9258ed/home-desktop.png)

![Mobile homepage](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/nanoid-security-f9258ed/home-mobile.png)

![Desktop links page](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/nanoid-security-f9258ed/links-desktop.png)

[Full verification output](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/gstj/pr-assets-dump/assets/nanoid-security-f9258ed/verification.txt)
