### PR TITLE
fix(security): pin nanoid 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   lodash: ^4.18.0
   minimatch@3: ^3.1.3
   minimatch@9: ^9.0.7
-  nanoid@3: ^3.3.17
+  nanoid@3: ^3.3.18
   picomatch@2: ^2.3.2
   sharp: ^0.35.0
   undici@7: ^7.29.0
@@ -1933,8 +1933,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3602,7 +3602,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3750,7 +3750,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ overrides:
   lodash: "^4.18.0"
   "minimatch@3": "^3.1.3"
   "minimatch@9": "^9.0.7"
-  "nanoid@3": "^3.3.17"
+  "nanoid@3": "^3.3.18"
   "picomatch@2": "^2.3.2"
   sharp: "^0.35.0"
   "undici@7": "^7.29.0"
@@ -97,7 +97,7 @@ minimumReleaseAgeExclude:
   - icu-minify@4.13.4
   - js-yaml@4.3.1
   - miniflare@5.20260730.0-alpha
-  - nanoid@3.3.17
+  - nanoid@3.3.18
   - next@16.2.12
   - next-intl@4.13.4
   - next-intl-swc-plugin-extractor@4.13.4


### PR DESCRIPTION
## Summary

The production dependency tree now resolves Nano ID 3.3.18, removing GHSA-2v37-7h3g-55p8.

## Details

- Moves the targeted pnpm override and 14-day package quarantine exception from Nano ID 3.3.17 to 3.3.18.
- Regenerates the lockfile so PostCSS resolves only Nano ID 3.3.18.
- The site doesn't call the affected custom generator APIs. PostCSS calls the standard generator with a constant size of six, so requests couldn't reach the vulnerable path before this update.

## Testing steps

1. From the repository root:

   ```sh
   pnpm install --frozen-lockfile
   pnpm audit --audit-level low
   pnpm why nanoid
   pnpm run build
   ```

   Every command should exit 0. The audit should report no known vulnerabilities, and the dependency output should show one resolved version at 3.3.18.

2. Start the production build:

   ```sh
   pnpm start
   ```

   Wait until the terminal prints `Ready` and a local URL.

3. Open `/en-US` from the local URL at 1440 x 1000 and 390 x 844. Confirm the hero shows Gabriel Taveira and Engineering Lead, the work cards and contact form are visible, and the page has no horizontal scrolling or overlapping text.
4. Open `/en-US/links` at 1440 x 1000. Confirm five links labeled LinkedIn, GitHub, Email, Medium, and Space Cast.

![Desktop homepage](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/181591eee4b121fb0884af67f737aabfb8d1446c/assets/nanoid-3.3.18-58fc13c/home-desktop.png)

![Mobile homepage](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/181591eee4b121fb0884af67f737aabfb8d1446c/assets/nanoid-3.3.18-58fc13c/home-mobile.png)

![Desktop links page](https://raw.githubusercontent.com/GSTJ/gabriel-taveira-portfolio/181591eee4b121fb0884af67f737aabfb8d1446c/assets/nanoid-3.3.18-58fc13c/links-desktop.png)